### PR TITLE
[e2g]: adding filtergroups

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -9,3 +9,4 @@ checks:
     - "unset-memory-requirements"
     - "no-read-only-root-fs"
     - "default-service-account"
+    - "use-namespace"

--- a/charts/e2g/.kube-linter.yaml
+++ b/charts/e2g/.kube-linter.yaml
@@ -1,0 +1,5 @@
+---
+checks:
+  exclude:
+    - (( prepend ))
+    - "use-namespace"

--- a/charts/e2g/.kube-linter.yaml
+++ b/charts/e2g/.kube-linter.yaml
@@ -1,5 +1,0 @@
----
-checks:
-  exclude:
-    - (( prepend ))
-    - "use-namespace"

--- a/charts/e2g/Chart.yaml
+++ b/charts/e2g/Chart.yaml
@@ -3,7 +3,7 @@ name: e2g
 description: "e2guardian Chart"
 type: application
 version: 1.2.0
-appVersion: 5.3.4 
+appVersion: 5.4
 home: "https://github.com/e2guardian/e2guardian/"
 keywords:
   - proxy

--- a/charts/e2g/Chart.yaml
+++ b/charts/e2g/Chart.yaml
@@ -3,7 +3,8 @@ name: e2g
 description: "e2guardian Chart"
 type: application
 version: 1.2.0
-appVersion: 5.4
+appVersion: "5.4"
+icon: "http://e2guardian.org/cms/images/banners/logo-guardian.png"
 home: "https://github.com/e2guardian/e2guardian/"
 keywords:
   - proxy

--- a/charts/e2g/Chart.yaml
+++ b/charts/e2g/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: e2g
 description: "e2guardian Chart"
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: 5.3.4 
 home: "https://github.com/e2guardian/e2guardian/"
 keywords:
@@ -26,8 +26,7 @@ sources:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - "[BugFix]: additional volume mounts"
-    - "[Feature]: Bump e2g version"
+    - "[Added]: filtergroups config"
   artifacthub.io/prerelease: "false"
   artifacthub.io/images: |
     - name: e2g-5 

--- a/charts/e2g/Chart.yaml
+++ b/charts/e2g/Chart.yaml
@@ -28,6 +28,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - "[Added]: filtergroups config"
+    - "[Bump] e2g to 5.4"
   artifacthub.io/prerelease: "false"
   artifacthub.io/images: |
     - name: e2g-5 

--- a/charts/e2g/README.md
+++ b/charts/e2g/README.md
@@ -70,9 +70,10 @@ Major Changes to functions are documented with the version affected. **Before up
 | deployment.replicaCount | int | 1 | Amount of Replicas deployed |
 | deployment.selectorLabels | object | `{}` | Define SelectorLabels for the Pod Template |
 | deployment.strategy | object | `{}` | Deployment [Update Strategy](https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend). **Deployments only** |
-| e2g.config | string | `nil` | e2g config as string |
-| e2g.lists | list | `[]` | Array of e2g stories as string |
-| e2g.story | list | `[]` | Array of e2g stories as string |
+| e2g.config | string | `nil` | e2g config mounted in e2guardian.conf |
+| e2g.filtergroups | list | `[]` | Array of e2g config for a filgergroup mounted as /usr/local/e2guardian/etc/e2guardian/e2guardianf{{ id }}.conf |
+| e2g.lists | list | `[]` | Array of e2g stories as string mounted in /usr/local/e2guardian/etc/e2guardian/listen/{{ $i }}.list |
+| e2g.story | list | `[]` | Array of e2g stories as string mounted in /usr/local/e2guardian/etc/e2guardian/{{ $i }}.story |
 | fullnameOverride | string | `""` | Overwrite `lib.utils.common.fullname` output |
 | global.defaultTag | string | `""` | Global Docker Image Tag declaration. Will be used as default tag, if no tag is given by child |
 | global.imagePullPolicy | string | `""` | Global Docker Image Pull Policy declaration. Will overwrite all child .pullPolicy fields. |
@@ -102,13 +103,13 @@ Major Changes to functions are documented with the version affected. **Before up
 | pod.podAnnotations | object | `{}` | Pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) are only added for the pod |
 | pod.podFields | object | `{"terminationGracePeriodSeconds":0}` | Add extra field to the [Pod Template](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplate-v1-core) if not available as value. |
 | pod.podLabels | object | `{}` | Pod [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) are only added for the pod |
-| pod.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534}` | Pod [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
+| pod.podSecurityContext | object | `{"fsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Pod [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | pod.ports | list | `[{"containerPort":1344,"name":"icap","protocol":"TCP"},{"containerPort":8080,"name":"http","protocol":"TCP"},{"containerPort":8443,"name":"https","protocol":"TCP"}]` | Configure Container Ports |
 | pod.priorityClassName | string | `""` | Pod [priorityClassName](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass) |
 | pod.readinessProbe | object | `{"initialDelaySeconds":5,"periodSeconds":1,"tcpSocket":{"port":1344}}` | Container [ReadinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes) |
 | pod.resources | object | `{}` | Configure Container [Resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | pod.restartPolicy | string | `nil` | Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy |
-| pod.securityContext | object | `{}` | Container [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
+| pod.securityContext | object | `{"allowPrivilegeEscalation":false,"runAsGroup":65534,"runAsUser":65534}` | Container [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | pod.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | pod.serviceAccount.apiVersion | string | v1 | Configure the api version used |
 | pod.serviceAccount.automountServiceAccountToken | bool | `true` | (bool) AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. |

--- a/charts/e2g/README.md
+++ b/charts/e2g/README.md
@@ -151,7 +151,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | statefulset.enabled | bool | `false` | Enable statefulset |
 | statefulset.labels | object | `{}` | Merges given labels with common labels |
 | statefulset.podManagementPolicy | string | `""` | Statefulset [Management Policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies). **Statefulset only** |
-| statefulset.replicaCount | int | `1` | Amount of Replicas deployed |
+| statefulset.replicaCount | int | `3` | Amount of Replicas deployed |
 | statefulset.rollingUpdatePartition | string | `""` | Statefulset [Update Pratition](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions). **Statefulset only** |
 | statefulset.selectorLabels | object | `{}` | Define SelectorLabels for the Pod Template |
 | statefulset.serviceName | string | `""` | Define a Service for the Statefulset |

--- a/charts/e2g/README.md
+++ b/charts/e2g/README.md
@@ -1,6 +1,6 @@
 # E2guardian
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 e2guardian Chart
 

--- a/charts/e2g/README.md
+++ b/charts/e2g/README.md
@@ -69,7 +69,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | deployment.labels | object | `{}` | Merges given labels with common labels |
 | deployment.replicaCount | int | 1 | Amount of Replicas deployed |
 | deployment.selectorLabels | object | `{}` | Define SelectorLabels for the Pod Template |
-| deployment.strategy | object | `{}` | Deployment [Update Strategy](https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend). **Deployments only** |
+| deployment.strategy | object | `{"type":"RollingUpdate"}` | Deployment [Update Strategy](https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend). **Deployments only** |
 | e2g.config | string | `nil` | e2g config mounted in e2guardian.conf |
 | e2g.filtergroups | list | `[]` | Array of e2g config for a filgergroup mounted as /usr/local/e2guardian/etc/e2guardian/e2guardianf{{ id }}.conf |
 | e2g.lists | list | `[]` | Array of e2g stories as string mounted in /usr/local/e2guardian/etc/e2guardian/listen/{{ $i }}.list |

--- a/charts/e2g/examples/simple.yaml
+++ b/charts/e2g/examples/simple.yaml
@@ -4,6 +4,542 @@ deployment:
 
 ## Set e2g config lists and stories
 e2g:
+  filtergroups:
+    - id: 1
+      config: | 
+        # e2guardian filter group config file for version 5.3.5
+
+        # This file is re-read on gentle restart and any changes actioned
+
+        # Filter group mode IS NOT LONGER SUPPORTED
+        # Unauthenticated users are treated as being in the default filter group.
+        # groupmode = 1 #DISABLED
+
+        # Filter group name
+        # Used to fill in the -FILTERGROUP- placeholder in the HTML template file, and to
+        # name the group in the access logs
+        # Defaults to empty string
+        #groupname = ''
+        groupname = 'no_name_group'
+
+        # Much logic has moved to storyboard files
+        storyboard = '/usr/local/e2guardian/etc/e2guardian/examplef1.story'
+
+        # Enable legacy (DG) ssl logic
+        #
+        # The following option is replaced by storyboard logic
+        # ssllegacylogic = off
+
+        # Content filtering files location
+
+        bannedphraselist = '/usr/local/e2guardian/etc/e2guardian/lists/bannedphraselist'
+        weightedphraselist = '/usr/local/e2guardian/etc/e2guardian/lists/weightedphraselist'
+        exceptionphraselist = '/usr/local/e2guardian/etc/e2guardian/lists/exceptionphraselist'
+        ## To use new phraselists comment the last three lines and
+        ## uncommnet the next 3 lines
+        #bannedphraselist = '/usr/local/e2guardian/etc/e2guardian/lists/newbannedphraselist'
+        #weightedphraselist = '/usr/local/e2guardian/etc/e2guardian/lists/newweightedphraselist'
+        #exceptionphraselist = '/usr/local/e2guardian/etc/e2guardian/lists/newexceptionphraselist'
+
+        ### NOTE - New format for all other list definitions in v5.0
+        ###        see notes/V5_list_definition for details
+
+        #banned lists
+        sitelist = 'name=banned,messageno=500,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedsitelist'
+        ipsitelist = 'name=banned,messageno=510,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedsiteiplist'
+        urllist = 'name=banned,messageno=501,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedurllist'
+        regexpboollist = 'name=banned,messageno=503,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedregexpurllist'
+        regexpboollist = 'name=banneduseragent,messageno=522,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedregexpuseragentlist'
+
+        sitelist = 'name=bannedssl,messageno=520,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedsslsitelist'
+        ipsitelist = 'name=bannedssl,messageno=520,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedsslsiteiplist'
+
+        #grey (i.e. content check) lists
+        sitelist = 'name=grey,path=/usr/local/e2guardian/etc/e2guardian/lists/greysitelist'
+        ipsitelist = 'name=grey,path=/usr/local/e2guardian/etc/e2guardian/lists/greysiteiplist'
+        urllist = 'name=grey,path=/usr/local/e2guardian/etc/e2guardian/lists/greyurllist'
+        sitelist = 'name=greyssl,path=/usr/local/e2guardian/etc/e2guardian/lists/greysslsitelist'
+        ipsitelist = 'name=greyssl,path=/usr/local/e2guardian/etc/e2guardian/lists/greysslsiteiplist'
+
+        #exception lists
+        sitelist = 'name=exception,messageno=602,path=/usr/local/e2guardian/etc/e2guardian/lists/exceptionsitelist'
+        ipsitelist = 'name=exception,messageno=602,path=/usr/local/e2guardian/etc/e2guardian/lists/exceptionsiteiplist'
+        urllist = 'name=exception,messageno=603,path=/usr/local/e2guardian/etc/e2guardian/lists/exceptionurllist'
+        regexpboollist = 'name=exception,messageno=609,path=/usr/local/e2guardian/etc/e2guardian/lists/exceptionregexpurllist'
+        regexpboollist = 'name=exceptionuseragent,messageno=610,path=/usr/local/e2guardian/etc/e2guardian/lists/exceptionregexpuseragentlist'
+
+        sitelist = 'name=refererexception,messageno=620,path=/usr/local/e2guardian/etc/e2guardian/lists/refererexceptionsitelist'
+        ipsitelist = 'name=refererexception,messageno=620,path=/usr/local/e2guardian/etc/e2guardian/lists/refererexceptionsiteiplist'
+        urllist = 'name=refererexception,messageno=620,path=/usr/local/e2guardian/etc/e2guardian/lists/refererexceptionurllist'
+        sitelist = 'name=embededreferer,path=/usr/local/e2guardian/etc/e2guardian/lists/embededreferersitelist'
+        ipsitelist = 'name=embededreferer,path=/usr/local/e2guardian/etc/e2guardian/lists/embededreferersiteiplist'
+        urllist = 'name=embededreferer,path=/usr/local/e2guardian/etc/e2guardian/lists/embededrefererurllist'
+
+        #modification lists
+        regexpreplacelist = 'name=change,path=/usr/local/e2guardian/etc/e2guardian/lists/urlregexplist'
+        regexpreplacelist = 'name=sslreplace,path=/usr/local/e2guardian/etc/e2guardian/lists/sslsiteregexplist'
+
+        #redirection lists
+        regexpreplacelist = 'name=redirect,path=/usr/local/e2guardian/etc/e2guardian/lists/urlredirectregexplist'
+
+        contentregexplist = '/usr/local/e2guardian/etc/e2guardian/lists/contentregexplist'
+
+        # local versions of lists
+
+        #local banned
+        sitelist = 'name=localbanned,messageno=560,path=/usr/local/e2guardian/etc/e2guardian/lists/localbannedsitelist'
+        #ipsitelist = 'name=localbanned,messageno=560,path=/usr/local/e2guardian/etc/e2guardian/lists/localbannedsiteiplist'
+        #urllist = 'name=localbanned,messageno=561,path=/usr/local/e2guardian/etc/e2guardian/lists/localbannedurllist'
+        #sitelist = 'name=localbannedssl,messageno=580,path=/usr/local/e2guardian/etc/e2guardian/lists/localbannedsslsitelist'
+        #ipsitelist = 'name=localbannedssl,messageno=580,path=/usr/local/e2guardian/etc/e2guardian/lists/localbannedsslsiteiplist'
+        searchlist = 'name=localbanned,messageno=581,path=/usr/local/e2guardian/etc/e2guardian/lists/localbannedsearchlist'
+
+        #local grey lists
+        sitelist = 'name=localgrey,path=/usr/local/e2guardian/etc/e2guardian/lists/localgreysitelist'
+        #ipsitelist = 'name=localgrey,path=/usr/local/e2guardian/etc/e2guardian/lists/localgreysiteiplist'
+        #urllist = 'name=localgrey,path=/usr/local/e2guardian/etc/e2guardian/lists/localgreyurllist'
+        sitelist = 'name=localgreyssl,path=/usr/local/e2guardian/etc/e2guardian/lists/localgreysslsitelist'
+        #ipsitelist = 'name=localgreyssl,path=/usr/local/e2guardian/etc/e2guardian/lists/localgreysslsiteiplist'
+
+        #local exception lists
+        sitelist = 'name=localexception,messageno=662,path=/usr/local/e2guardian/etc/e2guardian/lists/localexceptionsitelist'
+        #ipsitelist = 'name=localexception,messageno=662,path=/usr/local/e2guardian/etc/e2guardian/lists/localexceptionsiteiplist'
+        #urllist = 'name=localexception,messageno=663,path=/usr/local/e2guardian/etc/e2guardian/lists/localexceptionurllist'
+
+
+        # Filetype filtering
+        #
+        # Allow bannedregexpurllist with grey list mode
+        #
+        # The following option is replaced by storyboard logic
+        # bannedregexwithblanketblock = off
+        #
+        # The following option is replaced by storyboard logic
+        #blockdownloads = off
+
+        # Phrase filtering additional mime types (by default text/*)
+        # textmimetypes = 'application/xhtml+xml,application/xml,application/json,application/javascript,application/x-javascript'
+
+        # Uncomment the two lines below if want to only allow extentions/mime types in these lists
+        # You will also need to uncomment the checkfiletype function in site.story to enable this
+        #fileextlist = 'name=exceptionextension,path=/usr/local/e2guardian/etc/e2guardian/lists/exceptionextensionlist'
+        #mimelist = 'name=exceptionmime,path=/usr/local/e2guardian/etc/e2guardian/lists/exceptionmimetypelist'
+        #
+        # Use the following lists to block specific kinds of file downloads.
+        #
+        fileextlist = 'name=bannedextension,messageno=900,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedextensionlist'
+        mimelist = 'name=bannedmime,messageno=800,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedmimetypelist'
+        #
+        # In either file filtering mode, the following list can be used to override
+        # MIME type & extension blocks for particular domains & URLs (trusted download sites).
+        #
+        sitelist = 'name=exceptionfile,path=/usr/local/e2guardian/etc/e2guardian/lists/exceptionfilesitelist'
+        ipsitelist = 'name=exceptionfile,path=/usr/local/e2guardian/etc/e2guardian/lists/exceptionfilesiteiplist'
+        urllist = 'name=exceptionfile,path=/usr/local/e2guardian/etc/e2guardian/lists/exceptionfileurllist'
+
+        # POST protection (web upload and forms)
+        # does not block forms without any file upload, i.e. this is just for
+        # blocking or limiting uploads
+        # measured in kibibytes after MIME encoding and header bumph
+        # use 0 for a complete block
+        # use higher (e.g. 512 = 512Kbytes) for limiting
+        # use -1 for no blocking
+        # NOTE: POST PROTECTION IS NOT YET IMPLIMENTED IN V5
+        #maxuploadsize = 512
+        #maxuploadsize = 0
+        maxuploadsize = -1
+
+        # Categorise without blocking:
+        # Supply categorised lists here and the category string shall be logged against
+        # matching requests, but matching these lists does not perform any filtering
+        # action.
+        #sitelist = 'name=log,path=/usr/local/e2guardian/etc/e2guardian/lists/logsitelist'
+        #ipsitelist = 'name=log,path=/usr/local/e2guardian/etc/e2guardian/lists/logsiteiplist'
+        #urllist = 'name=log,path=/usr/local/e2guardian/etc/e2guardian/lists/logurllist'
+        #regexpboollist = 'name=log,path=/usr/local/e2guardian/etc/e2guardian/lists/logregexpurllist'
+
+        # Outgoing HTTP header rules:
+        # Optional lists for blocking based on, and modification of, outgoing HTTP
+        # request headers.  Format for headerregexplist is one modification rule per
+        # line, similar to content/URL modifications.  Format for
+        # bannedregexpheaderlist is one regular expression per line, with matching
+        # headers causing a request to be blocked.
+        # Headers are matched/replaced on a line-by-line basis, not as a contiguous
+        # block.
+        # Use for example, to remove cookies or prevent certain user-agents.
+        regexpreplacelist = 'name=headermods,path=/usr/local/e2guardian/etc/e2guardian/lists/headerregexplist'
+        regexpboollist = 'name=bannedheader,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedregexpheaderlist'
+        regexpboollist = 'name=exceptionheader,path=/usr/local/e2guardian/etc/e2guardian/lists/exceptionregexpheaderlist'
+        # used for Youtube add cookies etc
+        regexpreplacelist = 'name=addheader,path=/usr/local/e2guardian/etc/e2guardian/lists/addheaderregexplist'
+
+        #Virus checking exceptions - matched urls will not be virus checked
+        #Note that you also need to amend site.story in order for this to work.
+        #mimelist = 'name=exceptionvirus,path=/usr/local/e2guardian/etc/e2guardian/lists/contentscanners/exceptionvirusmimetypelist'
+        #fileextlist = 'name=exceptionvirus,path=/usr/local/e2guardian/etc/e2guardian/lists/contentscanners/exceptionvirusextensionlist'
+        #sitelist = 'name=exceptionvirus,path=/usr/local/e2guardian/etc/e2guardian/lists/contentscanners/exceptionvirussitelist'
+        #ipsitelist = 'name=exceptionvirus,path=/usr/local/e2guardian/etc/e2guardian/lists/contentscanners/exceptionvirussiteiplist'
+        #urllist = 'name=exceptionvirus,path=/usr/local/e2guardian/etc/e2guardian/lists/contentscanners/exceptionvirusurllist'
+
+        # Weighted phrase mode
+        # Optional; overrides the weightedphrasemode option in e2guardian.conf
+        # for this particular group.  See documentation for supported values in
+        # that file.
+        #weightedphrasemode = 0
+
+        # Naughtiness limit
+        # This the limit over which the page will be blocked.  Each weighted phrase is given
+        # a value either positive or negative and the values added up.  Phrases to do with
+        # good subjects will have negative values, and bad subjects will have positive
+        # values.  See the weightedphraselist file for examples.
+        # As a guide:
+        # 50 is for young children,  100 for old children,  160 for young adults.
+        naughtynesslimit = 50
+
+        # Search term blocking
+        # Search terms can be extracted from search URLs and filtered using one or
+        # both of two different methods.
+
+        # Method 1 is that developed by Protex where specific
+        # search terms are contained in a bannedsearchlist.
+        # (localbannedsearchlist and bannedsearchoveridelist can be used to suppliment
+        # and overide this list as required.)
+        # These lists contain banned search words combinations on each line.
+        # Words are separated by '+' and must be in sorted order within a line.
+        #    so to block 'sexy girl' then the list must contain the line
+        #    	girl+sexy
+        #    and this will block both 'sexy girl' and 'girl sexy'
+        # To use this method, the searchregexplist must be enabled and the bannedsearchlist(s) defined
+
+        # Method 2 is uses the
+        # bannedphraselist, weightedphraselist and exceptionphraselist, with a separate
+        # threshold for blocking than that used for normal page content.
+        # To do this, the searchregexplist must be enabled and searchtermlimit
+        # must be greater than 0.
+
+        #
+        # Search engine regular expression list (need for both options)
+        # List of regular expressions for matching search engine URLs.  It is assumed
+        # that the search terms themselves will be contained in the
+        # of output of each expression.
+        regexpreplacelist = 'name=searchterms,path=/usr/local/e2guardian/etc/e2guardian/lists/searchregexplist'
+        #
+        # Banned Search Term list(s) for option 1
+        searchlist = 'name=banned,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedsearchlist'
+        searchlist = 'name=override,path=/usr/local/e2guardian/etc/e2guardian/lists/bannedsearchoveridelist'
+
+
+        # Search term limit (for Option 2)
+        # The limit over which requests will be blocked for containing search terms
+        # which match the weightedphraselist.  This should usually be lower than the
+        # 'naughtynesslimit' value above, because the amount of text being filtered
+        # is only a few words, rather than a whole page.
+        # This option must be uncommented if searchregexplist is uncommented.
+        # A value of 0 here indicates that search terms should be extracted,
+        # but no phrase filtering should be performed on the resulting text.
+        #searchtermlimit = 0
+        #
+        # Search term phrase lists (for Option 2)
+        # If the three lines below are uncommented, search term blocking will use
+        # the banned, weighted & exception phrases from these lists, instead of using
+        # the same phrase lists as for page content.  This is optional but recommended,
+        # as weights for individual phrases in the "normal" lists may not be
+        # appropriate for blocking when those phrases appear in a much smaller block
+        # of text.
+        # Please note that all or none of the below should be uncommented, not a
+        # mixture.
+        # NOTE: these are phrase lists and still use the old style defines
+        #bannedsearchtermlist = '/usr/local/e2guardian/etc/e2guardian/lists/bannedsearchtermlist'
+        #weightedsearchtermlist = '/usr/local/e2guardian/etc/e2guardian/lists/weightedsearchtermlist'
+        #exceptionsearchtermlist = '/usr/local/e2guardian/etc/e2guardian/lists/exceptionsearchtermlist'
+
+        # Category display threshold
+        # This option only applies to pages blocked by weighted phrase filtering.
+        # Defines the minimum score that must be accumulated within a particular
+        # category in order for it to show up on the block pages' category list.
+        # All categories under which the page scores positively will be logged; those
+        # that were not displayed to the user appear in brackets.
+        #
+        # -1 = display only the highest scoring category
+        # 0 = display all categories (default)
+        # > 0 = minimum score for a category to be displayed
+        categorydisplaythreshold = 0
+
+        # Embedded URL weighting
+        # When set to something greater than zero, this option causes URLs embedded within a
+        # page's HTML (from links, image tags, etc.) to be extracted and checked against the
+        # bannedsitelist and bannedurllist. Each link to a banned page causes the amount set
+        # here to be added to the page's weighting.
+        # The behaviour of this option with regards to multiple occurrences of a site/URL is
+        # affected by the weightedphrasemode setting.
+        #
+        # NB: Currently, this feature uses regular expressions that require the PCRE library.
+        # As such, it is only available if you compiled e2guardian with '--enable-pcre=yes'.
+        # You can check compile-time options by running 'e2guardian -v'.
+        #
+        # Set to 0 to disable.
+        # Defaults to 0.
+        # WARNING: This option is highly CPU intensive!
+        embeddedurlweight = 0
+
+        # Temporary Denied Page Bypass
+        # This provides a link on the denied page to bypass the ban for a few minutes.  To be
+        # secure it uses a random hashed secret generated at daemon startup.  You define the
+        # number of seconds the bypass will function for before the deny will appear again.
+        # To allow the link on the denied page to appear you will need to edit the template.html
+        # or e2guardian.pl file for your language.
+        # 300 = enable for 5 minutes
+        # 0 = disable ( defaults to 0 )
+        # -1 - depreciated - for backward compatability enables cgibypass with bypassversion 1
+        bypass = 0
+
+        # Byapss version 2 is experimental, provide a secure cgi communication (see notes/cgi_bypass documentation)
+        #
+
+        # Bypass version
+        # can be 1 or 2
+        # Always use v2 unless you have old style cgi hash generation in use
+        # Default is 1
+        # bypassversion = 2
+
+        # cgibypass - Use a separate program/CGI to (in v1 generate) or (in v2 validate) link
+        # 'on' or 'off' (default)
+        # cgibypass = 'off'
+
+        # Temporary Denied Page Bypass Secret Key
+        # Rather than generating a random key you can specify one.  It must be more than 8 chars.
+        # '' = generate a random one (recommended and default)
+        # 'Mary had a little lamb.' = an example
+        # '76b42abc1cd0fdcaf6e943dcbc93b826' = an example
+        bypasskey = ''
+
+        # magic key for cgi bypass v2 - used to sign communications between e2g and cgi
+        # default is blank
+        #cgikey = 'you must change this text in order to be secure'
+
+        #  Users will not be able to bypass sites/urls in these lists
+        sitelist = 'name=bannedbypass,messageno=500,path=/usr/local/e2guardian/etc/e2guardian/lists/domainsnobypass'
+        #ipsitelist = 'name=bannedbypass,messageno=500,path=/usr/local/e2guardian/etc/e2guardian/lists/ipnobypass'
+        #urllist = 'name=bannedbypass,messageno=501,path=/usr/local/e2guardian/etc/e2guardian/lists/urlnobypass'
+
+        # Infection/Scan Error Bypass
+        # Similar to the 'bypass' setting, but specifically for bypassing files scanned and found
+        # to be infected, or files that trigger scanner errors - for example, archive types with
+        # recognised but unsupported compression schemes, or corrupt archives.
+        # The option specifies the number of seconds for which the bypass link will be valid.
+        # 300 = enable for 5 minutes
+        # 0 = disable (default)
+        # -1 - depreciated - for backward compatability enables cgiinfectionbypass with bypassversion 1
+        infectionbypass = 0
+
+        # cgiinfectionbypass - Use a separate program/CGI to (v1 generate) or (v2 validate) link
+        # 'on' or 'off' (default)
+        # cgiinfectionbypass = 'off'
+
+        # Infection/Scan Error Bypass Secret Key
+        # Same as the 'bypasskey' option, but used for infection bypass mode.
+        infectionbypasskey = ''
+
+        # Infection/Scan Error Bypass on Scan Errors Only
+        # Enable this option to allow infectionbypass links only when virus scanning fails,
+        # not when a file is found to contain a virus.
+        # on = enable (default and highly recommended)
+        # off = disable
+        infectionbypasserrorsonly = on
+
+        # Disable content scanning
+        # If you enable this option you will disable content scanning for this group.
+        # Content scanning primarily is AV scanning (if enabled) but could include
+        # other types.
+        # (on|off) default = off.
+        disablecontentscan = off
+
+        # Disable content scanning with error (timeout, AV crash, etc)
+        # If you enable this option you will allow object with an unexpected result
+        # Content scanning primarily is AV scanning (if enabled) but could include
+        # other types.
+        # With "on" you can allow INFECTED objects
+        # (on|off) default = off. (default and highly recommended)
+        disablecontentscanerror = off
+
+        # If 'on' exception sites, urls, users etc will be scanned
+        # This is probably not desirable behavour as exceptions are
+        # supposed to be trusted and will increase load.
+        # Correct use of grey lists are a better idea.
+        # (on|off) default = off
+        contentscanexceptions = off
+
+        # Auth plugins
+        # Enable Deep URL Analysis
+        # When enabled, DG looks for URLs within URLs, checking against the bannedsitelist and
+        # bannedurllist. This can be used, for example, to block images originating from banned
+        # sites from appearing in Google Images search results, as the original URLs are
+        # embedded in the thumbnail GET requests.
+        # (on|off) default = off
+        deepurlanalysis = off
+
+        # reportinglevel
+        #
+        # -1 = log, but do not block - Stealth mode
+        #  0 = just say 'Access Denied'
+        #  1 = report why but not what denied phrase
+        #  2 = report fully
+        #  3 = use HTML template file (accessdeniedaddress ignored) - recommended
+        #
+        # If defined, this overrides the global setting in e2guardian.conf for
+        # members of this filter group.
+        #
+        reportinglevel = 3
+
+        # accessdeniedaddress is the address of your web server to which the cgi
+        # e2guardian reporting script was copied. Only used in reporting levels
+        # 1 and 2.
+        #
+        # This webserver must be either:
+        #  1. Non-proxied. Either a machine on the local network, or listed as an
+        #     exception in your browser's proxy configuration.
+        #  2. Added to the exceptionsitelist. Option 1 is preferable; this option is
+        #     only for users using both transparent proxying and a non-local server
+        #     to host this script.
+        #
+        #accessdeniedaddress = 'http://YOURSERVER.YOURDOMAIN/cgi-bin/e2guardian.pl'
+
+        # HTML Template override
+        # If defined, this specifies a custom HTML template file for members of this
+        # filter group, overriding the global setting in e2guardian.conf. This is
+        # only used in reporting level 3.
+        #
+        # The default template file path is <languagedir>/<language>/template.html
+        # e.g. /usr/local/e2guardian/share/e2guardian/languages/ukenglish/template.html when using 'ukenglish'
+        # language.
+        #
+        # This option generates a file path of the form:
+        # <languagedir>/<language>/<htmltemplate>
+        # e.g. /usr/local/e2guardian/share/e2guardian/languages/ukenglish/custom.html
+        #
+        #htmltemplate = 'custom.html'
+
+        #Template for use to report network issues and sites which are not responding
+        # The default template file path is <languagedir>/<language>/neterr_template.html
+        # e.g. /usr/local/e2guardian/share/e2guardian/languages/ukenglish/neterr_template.html when using 'ukenglish'
+        # language.
+        #neterrtemplate = 'custom_neterr_template.html'
+
+        # Non standard delimiter (only used with accessdeniedaddress)
+        # To help preserve the full banned URL, including parameters, the variables
+        # passed into the access denied CGI are separated using non-standard
+        # delimiters. This can be useful to ensure correct operation of the filter
+        # bypass modes. Parameters are split using "::" in place of "&", and "==" in
+        # place of "=".
+        # Default is enabled, but to go back to the standard mode, disable it.
+
+        #nonstandarddelimiter = off
+
+        # Email reporting - original patch by J. Gauthier
+
+        # Use SMTP
+        # If on, will enable system wide events to be reported by email.
+        # need to configure mail program (see 'mailer' in global config)
+        # and email recipients
+        # default usesmtp = off
+        #!! Not compiled !!usesmtp = off   #NOT YET TESTED
+
+        # mailfrom
+        # who the email would come from
+        # example: mailfrom = 'e2guardian@mycompany.com'
+        #!! Not compiled !!mailfrom = ''
+
+        # avadmin
+        # who the virus emails go to (if notify av is on)
+        # example: avadmin = 'admin@mycompany.com'
+        #!! Not compiled !!avadmin = ''
+
+        # contentdmin
+        # who the content emails go to (when thresholds are exceeded)
+        # and contentnotify is on
+        # example: contentadmin = 'admin@mycompany.com'
+        #!! Not compiled !!contentadmin = ''
+
+        # avsubject
+        # Subject of the email sent when a virus is caught.
+        # only applicable if notifyav is on
+        # default avsubject = 'e2guardian virus block'
+        #!! Not compiled !!avsubject = 'e2guardian virus block'
+
+        # content
+        # Subject of the email sent when violation thresholds are exceeded
+        # default contentsubject = 'e2guardian violation'
+        #!! Not compiled !!contentsubject = 'e2guardian violation'
+
+        # notifyAV
+        # This will send a notification, if usesmtp/notifyav is on, any time an
+        # infection is found.
+        # Important: If this option is off, viruses will still be recorded like a
+        # content infraction.
+        #!! Not compiled !!notifyav = off
+
+        # notifycontent
+        # This will send a notification, if usesmtp is on, based on thresholds
+        # below
+        #!! Not compiled !!notifycontent = off
+
+        # thresholdbyuser
+        # results are only predictable with user authenticated configs
+        # if enabled the violation/threshold count is kept track of by the user
+        #!! Not compiled !!thresholdbyuser = off
+
+        #violations
+        # number of violations before notification
+        # setting to 0 will never trigger a notification
+        #!! Not compiled !!violations = 0
+
+        #threshold
+        # this is in seconds. If 'violations' occur in 'threshold' seconds, then
+        # a notification is made.
+        # if this is set to 0, then whenever the set number of violations are made a
+        # notifaction will be sent.
+        #!! Not compiled !!threshold = 0
+
+        #NOTE to enable SSL MITM or NON-MITM SSL CERT checking
+        # enablessl must be defined as 'yes' in e2guardian.conf
+
+        #SSL certificate checking
+        # Check that ssl certificates for servers on https connections are valid
+        # and signed by a ca in the configured path
+        # ONLY for connections that are NOT MITM
+        #sslcertcheck = off - NOT implimented in V5 yet
+
+        #SSL man in the middle
+        # Forge ssl certificates for all non-exception sites, decrypt the data then re encrypt it
+        # using a different private key. Used to filter ssl sites
+        sslmitm = off
+
+        #Limit SSL MITM to sites in greysslsitelist(s)
+        # ignored if  sslmitm is off
+        # SSL sites not matching greysslsitelist will be treat as if sslmitm is off.
+        # The following option is replaced by storyboard logic
+        #onlymitmsslgrey = off  - ignored in V5
+
+        # Enable MITM site certificate checking
+        # ignored if  sslmitm is off
+        # default (recommended) is 'on'
+        mitmcheckcert = on
+
+        #Do not check ssl certificates for sites listed
+        # Can be used to allow sites with self-signed or invalid certificates
+        # or to reduced CPU load by not checking certs on heavily used sites (e.g. Google, Bing)
+        # Use with caution!
+        # Ignored if mitmcheckcert is 'off'
+        #nocheckcertsitelist = '/usr/local/e2guardian/etc/e2guardian/lists/nocheckcertsitelist'
+        sitelist = 'name=nocheckcert,path=/usr/local/e2guardian/etc/e2guardian/lists/nocheckcertsitelist'
+        ipsitelist = 'name=nocheckcert,path=/usr/local/e2guardian/etc/e2guardian/lists/nocheckcertsiteiplist'
+        #
+
+        # Auto switch to MITM with upstream connection error or to deliver block page
+        # ignored if  sslmitm is off
+        # To revert to v4 type behavour switch this off
+        # Default is 'on'
+        # automitm = on
   story:
     - | 
         .Include</usr/local/e2guardian/etc/e2guardian/common.story>

--- a/charts/e2g/templates/bundle.yaml
+++ b/charts/e2g/templates/bundle.yaml
@@ -83,7 +83,7 @@ resources:
         name: e2g-story
         labels: {{- include "lib.utils.common.labels" $| nindent 10 }}
       data:
-    {{- range $.Values.e2g.story }}
+    {{- range $i, $e := $.Values.e2g.story }}
         {{ $i }}.story: |-
           {{ $e | nindent 10 }}
     {{- end -}}
@@ -97,7 +97,7 @@ resources:
         name: e2g-filtergroups
         labels: {{- include "lib.utils.common.labels" $| nindent 10 }}
       data:
-    {{- range $i, $e := $.Values.e2g.filtergroups }}
+    {{- range $.Values.e2g.filtergroups }}
         e2guardianf{{ .id }}.conf: |-
           {{ .config | nindent 10 }}
     {{- end -}}

--- a/charts/e2g/templates/bundle.yaml
+++ b/charts/e2g/templates/bundle.yaml
@@ -73,5 +73,11 @@ resources:
           {{ $e | nindent 10 }}
       {{- end -}}
     {{- end -}}
+    {{- if $.Values.e2g.filtergroups }}
+      {{- range $i, $e := $.Values.e2g.filtergroups }}
+        e2guardianf{{ .id }}.conf: |-
+          {{ .config | nindent 10 }}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/e2g/templates/bundle.yaml
+++ b/charts/e2g/templates/bundle.yaml
@@ -48,7 +48,7 @@ resources:
     {{- toYaml $.Values.extraResources | nindent 2 }}
   {{- end }}
   
-  {{- if or ($.Values.e2g.config)}}
+  {{- if  $.Values.e2g.config }}
   - type: "raw"
     manifest: |
       apiVersion: v1
@@ -60,7 +60,7 @@ resources:
         e2guardian.conf: |-
     {{ $.Values.e2g.config | nindent 10 }}
   {{- end -}}
-  {{- if or ($.Values.e2g.lists)}}
+  {{- if $.Values.e2g.lists }}
   - type: "raw"
     manifest: |
       apiVersion: v1
@@ -74,7 +74,7 @@ resources:
           {{ $e | nindent 10 }}
     {{- end -}}
   {{- end -}}
-  {{- if or ($.Values.e2g.story)}}
+  {{- if $.Values.e2g.story }}
   - type: "raw"
     manifest: |
       apiVersion: v1
@@ -88,7 +88,7 @@ resources:
           {{ $e | nindent 10 }}
     {{- end -}}
   {{- end -}}
-  {{- if or ($.Values.e2g.filtergroups)}}
+  {{- if  $.Values.e2g.filtergroups }}
   - type: "raw"
     manifest: |
       apiVersion: v1

--- a/charts/e2g/templates/bundle.yaml
+++ b/charts/e2g/templates/bundle.yaml
@@ -48,7 +48,7 @@ resources:
     {{- toYaml $.Values.extraResources | nindent 2 }}
   {{- end }}
   
-  {{- if or ($.Values.e2g.config) ($.Values.e2g.story) ($.Values.e2g.lists) }}
+  {{- if or ($.Values.e2g.config)}}
   - type: "raw"
     manifest: |
       apiVersion: v1
@@ -57,27 +57,49 @@ resources:
         name: e2g-config
         labels: {{- include "lib.utils.common.labels" $| nindent 10 }}
       data:
-    {{- if $.Values.e2g.story }}
-      {{- range $i, $e := $.Values.e2g.story }}
-        {{ $i }}.story: |-
-          {{ $e | nindent 10 }}
-      {{- end -}}
-    {{- end -}}
-    {{- if $.Values.e2g.config }}
         e2guardian.conf: |-
-          {{ $.Values.e2g.config | nindent 10 }}
-    {{- end -}}
-    {{- if $.Values.e2g.lists }}
-      {{- range $i, $e := $.Values.e2g.lists }}
+    {{ $.Values.e2g.config | nindent 10 }}
+  {{- end -}}
+  {{- if or ($.Values.e2g.lists)}}
+  - type: "raw"
+    manifest: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: e2g-lists
+        labels: {{- include "lib.utils.common.labels" $| nindent 10 }}
+      data:
+    {{- range $i, $e := $.Values.e2g.lists }}
         {{ $i }}.list: |-
           {{ $e | nindent 10 }}
-      {{- end -}}
     {{- end -}}
-    {{- if $.Values.e2g.filtergroups }}
-      {{- range $i, $e := $.Values.e2g.filtergroups }}
+  {{- end -}}
+  {{- if or ($.Values.e2g.story)}}
+  - type: "raw"
+    manifest: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: e2g-story
+        labels: {{- include "lib.utils.common.labels" $| nindent 10 }}
+      data:
+    {{- range $i, $e := $.Values.e2g.story }}
+        {{ $i }}.story: |-
+          {{ $e | nindent 10 }}
+    {{- end -}}
+  {{- end -}}
+  {{- if or ($.Values.e2g.filtergroups)}}
+  - type: "raw"
+    manifest: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: e2g-filtergroups
+        labels: {{- include "lib.utils.common.labels" $| nindent 10 }}
+      data:
+    {{- range $i, $e := $.Values.e2g.filtergroups }}
         e2guardianf{{ .id }}.conf: |-
           {{ .config | nindent 10 }}
-      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/e2g/templates/bundle.yaml
+++ b/charts/e2g/templates/bundle.yaml
@@ -83,7 +83,7 @@ resources:
         name: e2g-story
         labels: {{- include "lib.utils.common.labels" $| nindent 10 }}
       data:
-    {{- range $i, $e := $.Values.e2g.story }}
+    {{- range $.Values.e2g.story }}
         {{ $i }}.story: |-
           {{ $e | nindent 10 }}
     {{- end -}}

--- a/charts/e2g/templates/e2g.tpl
+++ b/charts/e2g/templates/e2g.tpl
@@ -43,15 +43,15 @@ volumeMounts:
   {{ with $.Values.pod.volumeMounts }}
     {{ toYaml . | nindent 0 }}
   {{- end }}
-  {{- if $.Values.e2g.story }}
-    {{- range $i, $e := $.Values.e2g.story }}
+  {{- with $.Values.e2g.story }}
+    {{- range $i, $e := . }}
 - mountPath: /usr/local/e2guardian/etc/e2guardian/{{ $i }}.story
   name: e2g-story
   subPath: {{ $i }}.story
       {{- end }}
   {{- end }}
-  {{- if $.Values.e2g.lists }}
-    {{- range $i, $e := $.Values.e2g.lists }}
+  {{- with $.Values.e2g.lists }}
+    {{- range $i, $e := . }}
 - mountPath: /usr/local/e2guardian/etc/e2guardian/listen/{{ $i }}.list
   name: e2g-lists
   subPath: {{ $i }}.list

--- a/charts/e2g/templates/e2g.tpl
+++ b/charts/e2g/templates/e2g.tpl
@@ -16,7 +16,7 @@ limitations under the License.
 */}}
 {{- define "overwrite" -}}
 volumes:
-  {{- if or ($.Values.e2g.config) ($.Values.e2g.story)  ($.Values.e2g.lists) }}
+  {{- if or ($.Values.e2g.config) ($.Values.e2g.story)  ($.Values.e2g.lists) ($.Values.e2g.filtergroups) }}
 - name: "e2g-config"
   configMap:
     name: e2g-config
@@ -46,6 +46,13 @@ volumeMounts:
 - mountPath: /usr/local/e2guardian/etc/e2guardian/e2guardian.conf
   name: e2g-config
   subPath: e2guardian.conf
+  {{- end }}
+  {{ if $.Values.e2g.filtergroups }}
+    {{- range $i := $.Values.e2g.filtergroups }}
+- mountPath: /usr/local/e2guardian/etc/e2guardian/e2guardianf{{ .id }}.conf
+  name: e2g-config
+  subPath: e2guardianf{{ .id }}.conf
+    {{- end }}
   {{- end }}
   {{- if or ($.Values.e2g.config) ($.Values.e2g.story)  ($.Values.e2g.lists) }}
 podAnnotations:

--- a/charts/e2g/templates/e2g.tpl
+++ b/charts/e2g/templates/e2g.tpl
@@ -16,10 +16,25 @@ limitations under the License.
 */}}
 {{- define "overwrite" -}}
 volumes:
-  {{- if or ($.Values.e2g.config) ($.Values.e2g.story)  ($.Values.e2g.lists) ($.Values.e2g.filtergroups) }}
+  {{- if or ($.Values.e2g.config)  }}
 - name: "e2g-config"
   configMap:
     name: e2g-config
+  {{- end }}
+  {{- if or ($.Values.e2g.story)  }}
+- name: "e2g-story"
+  configMap:
+    name: e2g-story
+  {{- end }}
+  {{- if or ($.Values.e2g.lists)  }}
+- name: "e2g-lists"
+  configMap:
+    name: e2g-lists
+  {{- end }}
+  {{- if or ($.Values.e2g.filtergroups)  }}
+- name: "e2g-filtergroups"
+  configMap:
+    name: e2g-filtergroups
   {{- end }}
   {{ with $.Values.pod.volumes }}
     {{ toYaml . | nindent 0 }}
@@ -31,14 +46,14 @@ volumeMounts:
   {{- if $.Values.e2g.story }}
     {{- range $i, $e := $.Values.e2g.story }}
 - mountPath: /usr/local/e2guardian/etc/e2guardian/{{ $i }}.story
-  name: e2g-config
+  name: e2g-story
   subPath: {{ $i }}.story
       {{- end }}
   {{- end }}
   {{- if $.Values.e2g.lists }}
     {{- range $i, $e := $.Values.e2g.lists }}
 - mountPath: /usr/local/e2guardian/etc/e2guardian/listen/{{ $i }}.list
-  name: e2g-config
+  name: e2g-lists
   subPath: {{ $i }}.list
     {{- end }}
   {{- end }}
@@ -47,10 +62,10 @@ volumeMounts:
   name: e2g-config
   subPath: e2guardian.conf
   {{- end }}
-  {{ if $.Values.e2g.filtergroups }}
-    {{- range $i := $.Values.e2g.filtergroups }}
+  {{ with $.Values.e2g.filtergroups }}
+    {{- range  . }}
 - mountPath: /usr/local/e2guardian/etc/e2guardian/e2guardianf{{ .id }}.conf
-  name: e2g-config
+  name: e2g-filtergroups
   subPath: e2guardianf{{ .id }}.conf
     {{- end }}
   {{- end }}

--- a/charts/e2g/templates/e2g.tpl
+++ b/charts/e2g/templates/e2g.tpl
@@ -16,22 +16,22 @@ limitations under the License.
 */}}
 {{- define "overwrite" -}}
 volumes:
-  {{- if or ($.Values.e2g.config)  }}
+  {{- if $.Values.e2g.config  }}
 - name: "e2g-config"
   configMap:
     name: e2g-config
   {{- end }}
-  {{- if or ($.Values.e2g.story)  }}
+  {{- if $.Values.e2g.story  }}
 - name: "e2g-story"
   configMap:
     name: e2g-story
   {{- end }}
-  {{- if or ($.Values.e2g.lists)  }}
+  {{- if $.Values.e2g.lists  }}
 - name: "e2g-lists"
   configMap:
     name: e2g-lists
   {{- end }}
-  {{- if or ($.Values.e2g.filtergroups)  }}
+  {{- if $.Values.e2g.filtergroups  }}
 - name: "e2g-filtergroups"
   configMap:
     name: e2g-filtergroups

--- a/charts/e2g/templates/e2g.tpl
+++ b/charts/e2g/templates/e2g.tpl
@@ -69,7 +69,7 @@ volumeMounts:
   subPath: e2guardianf{{ .id }}.conf
     {{- end }}
   {{- end }}
-  {{- if or ($.Values.e2g.config) ($.Values.e2g.story)  ($.Values.e2g.lists) }}
+  {{- if or ($.Values.e2g.config) ($.Values.e2g.story)  ($.Values.e2g.lists) ($.Values.e2g.filtergroups) }}
 podAnnotations:
   checksum/config: {{ tpl (toYaml .Values.e2g) . | sha256sum }}
   {{- end }}

--- a/charts/e2g/values.yaml
+++ b/charts/e2g/values.yaml
@@ -27,16 +27,24 @@ global:
 e2g:
 
   ## Define e2g stories
-  # e2g.story -- Array of e2g stories as string
+  # e2g.story -- Array of e2g stories as string mounted in /usr/local/e2guardian/etc/e2guardian/{{ $i }}.story
   story: []
 
   ## Define e2g config
-  # e2g.config -- e2g config as string
+  # e2g.config -- e2g config mounted in e2guardian.conf
   config:
 
   ## Define e2g lists
-  # e2g.lists -- Array of e2g stories as string
+  # e2g.lists -- Array of e2g stories as string mounted in /usr/local/e2guardian/etc/e2guardian/listen/{{ $i }}.list
   lists: []
+
+  ## Define e2g filtergroup config
+  # e2g.filtergroups -- Array of e2g config for a filgergroup mounted as /usr/local/e2guardian/etc/e2guardian/e2guardianf{{ id }}.conf
+  filtergroups: []
+  #  - id: 1
+  #    config: | 
+  #     deepurlanalysis = off
+
 
 ## Common Values
 ##
@@ -174,6 +182,7 @@ pod:
   # pod.podSecurityContext -- Pod [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
   podSecurityContext: 
     runAsNonRoot: true
+    fsGroup: 65534
     runAsUser: 65534 
   
   ## Pod Initcontainers
@@ -326,7 +335,9 @@ pod:
   ## Container SecurityContext
   # pod.securityContext -- Container [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
   securityContext: 
-    {}
+    runAsUser: 65534
+    runAsGroup: 65534
+    allowPrivilegeEscalation: false
   
   ## ReadinessProbe Configuration
   # pod.readinessProbe -- Container [ReadinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)

--- a/charts/e2g/values.yaml
+++ b/charts/e2g/values.yaml
@@ -407,10 +407,8 @@ deployment:
 
   ## Deployment Update Strategy
   # deployment.strategy -- Deployment [Update Strategy](https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend). **Deployments only**
-  strategy: {}
-  #  type: RollingUpdate
-  #    maxSurge: 1
-  #    maxUnavailable: 0
+  strategy:
+   type: RollingUpdate
 
   ## Deployment Extra Values
   # deployment.deploymentExtras -- Extra Fields for Deployment Manifest

--- a/charts/e2g/values.yaml
+++ b/charts/e2g/values.yaml
@@ -403,7 +403,7 @@ deployment:
   ## Amount of Replicas
   # deployment.replicaCount -- Amount of Replicas deployed
   # @default -- 1
-  replicaCount: 1
+  replicaCount: 3
 
   ## Deployment Update Strategy
   # deployment.strategy -- Deployment [Update Strategy](https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend). **Deployments only**
@@ -450,7 +450,7 @@ statefulset:
 
   ## Amount of Replicas
   # statefulset.replicaCount -- Amount of Replicas deployed
-  replicaCount: 1
+  replicaCount: 3
 
   ## Statefulset Pod Management Policy
   # statefulset.podManagementPolicy -- Statefulset [Management Policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies). **Statefulset only**


### PR DESCRIPTION
Signed-off-by: Kevin Klopfenstein <kk@sudo-i.net>

<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:
- adding filtergroups
- exclude use-namespace from kube-linter global
- bump e2g

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
- fixes #57 

**Notes for Reviewer**:


**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
