### PR TITLE
[manifest]: Add PodDisruptionBudget v1 to manifest helm chart

### DIFF
--- a/charts/manifests/Chart.yaml
+++ b/charts/manifests/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: manifests
 description: "Bedag's Manifest chart. Library full of basic kubernetes manifests."
 type: library
-version: 0.8.1
+version: 0.8.2
 icon: "https://www.bedag.ch/wGlobal/wGlobal/layout/images/logo.svg"
 keywords:
 - Bedag

--- a/charts/manifests/README.md
+++ b/charts/manifests/README.md
@@ -1,6 +1,6 @@
 # Manifests Library
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 This library's purpose is to have more flexibility as chart author but at the same time have kubernetes manifests managed in a central library. This way you can avoid big surprises when Kubernetes has breaking changes in any of their APIs. Currently we support a base set of resources. Resources may be added as soon as we see or get a request that there's a need for it. This chart is still under development and testing, since it's rather complex. Feel free to use it. Our goal is to get it as reliable as possible.
 
@@ -8,7 +8,7 @@ This library's purpose is to have more flexibility as chart author but at the sa
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| SRE | sre@bedag.ch |  |
+| SRE | <sre@bedag.ch> |  |
 
 # Install Chart
 

--- a/charts/manifests/templates/manifests/_podDisruptionBudget.tpl
+++ b/charts/manifests/templates/manifests/_podDisruptionBudget.tpl
@@ -25,7 +25,11 @@ kind: PodDisruptionBudget
         {{- if $pdb.apiVersion }}
 apiVersion: {{ $pdb.apiVersion }}
         {{- else }}
+          {{- if semverCompare ">=1.21-0" (include "lib.utils.common.capabilities" $context) }}
+apiVersion: policy/v1
+          {{- else }}
 apiVersion: policy/v1beta1
+          {{- end }}
         {{- end }}
 metadata:
   name: {{ include "bedag-lib.utils.common.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Adrian Berger <adrian.berger@bedag.ch>

<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:

Adds new PodDisruptionBudget api v1:
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125

Since we don't have the possibility to add empty selector field, this is not a breaking change.

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Chart Version bumped
- [x] All commits are signed-off
