### PR TITLE
[common]: fix controller replica count for zero & binaryfile volumemount

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 9.0.2
+version: 9.0.3
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -27,4 +27,5 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
-    - "[Fixed]: Schema Json for NetworkPolicy"
+    - "[Fixed]: Allows controller replica of count 0"
+    - "[Fixed]: Typo in volumemout of binaryfiles"

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 9.0.2](https://img.shields.io/badge/Version-9.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 9.0.3](https://img.shields.io/badge/Version-9.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/templates/_deployment.yaml
+++ b/charts/common/templates/_deployment.yaml
@@ -14,7 +14,7 @@ metadata:
 {{ include "library.labels.standard" $root | indent 4 }}
     app.kubernetes.io/component: {{ $name }}
 spec:
-  replicas: {{ $deployment.replicas | default 1 }}
+  replicas: {{ if kindIs "float64" $deployment.replicas }}{{ $deployment.replicas }}{{ else }}{{ 1 }}{{ end }}
   revisionHistoryLimit: {{ $deployment.revisionHistoryLimit | default 3 }}
   strategy:
     {{- if $deployment.strategy }}

--- a/charts/common/templates/_pod.yaml
+++ b/charts/common/templates/_pod.yaml
@@ -100,7 +100,7 @@ volumes:
   {{- if $binaryFiles }}
   - name: {{ $containerName }}-binaryfiles
     secret:
-      secretName: {{ template "library.name" $root }}-{{ $name }}-{{ $containerName }}-binaryfile
+      secretName: {{ template "library.name" $root }}-{{ $name }}-{{ $containerName }}-binaryfiles
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:
- fix usage of controller replica with count 0 (e.g. value `components.backend.controller.replicas: 0`)
- fix volumemount of binaryfiles


**Notes for Reviewer**:

- replicas: see https://github.com/helm/helm/issues/3164#issuecomment-636267669
- binaryfile: see https://github.com/bedag/helm-charts/blob/master/charts/common/templates/_binaryfiles.yaml#L15

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
