### PR TITLE
[common]: add egress and namespaceSelector in networkpolicy

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 9.1.3
+version: 10.0.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -27,5 +27,6 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
-    - "[Fixed]: Allows controller replica of count 0"
-    - "[Fixed]: Typo in volumemout of binaryfiles"
+    - "[Changed]: possibility to create multiple networkpolicies"
+    - "[Added]: namespaceSelector in networkpolicy"
+    - "[Added]: egress networkpolicies"

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -46,7 +46,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | components.component-1.controller.tolerations | list | `[]` |  |
 | components.component-1.controller.type | string | `"Deployment"` |  |
 | components.component-1.controller.volumes | list | `[]` |  |
-| components.component-1.networkpolicies.networkpolicy-1.deploy | bool | `false` |  |
+| components.component-1.networkpolicies | object | `{}` |  |
 | components.component-1.services.service-1.deploy | bool | `false` |  |
 | defaultTag | string | `"latest"` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/ssl-redirect" | string | `"true"` |  |

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 9.1.3](https://img.shields.io/badge/Version-9.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 10.0.0](https://img.shields.io/badge/Version-10.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 
@@ -22,6 +22,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | :----------- | :---------------- | :--------------------- | :-------------- |
 |logPersistence removed|8.0.0|Removes logPersistence functionality as it can be achieved with volumeMounts & extraVolumeClaimTemplates and is buggy anyway.|https://github.com/bedag/helm-charts/pull/68|
 |networkpolicy template changes|9.0.0|add possibility to define more than one Port in networkpolicy|https://github.com/bedag/helm-charts/pull/70|
+|networkpolicy template changes|10.0.0|add possibility to create multiple networkpolicies|https://github.com/bedag/helm-charts/pull/77|
 
 ## Values
 
@@ -45,7 +46,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | components.component-1.controller.tolerations | list | `[]` |  |
 | components.component-1.controller.type | string | `"Deployment"` |  |
 | components.component-1.controller.volumes | list | `[]` |  |
-| components.component-1.networkpolicy.deploy | bool | `false` |  |
+| components.component-1.networkpolicies.networkpolicy-1.deploy | bool | `false` |  |
 | components.component-1.services.service-1.deploy | bool | `false` |  |
 | defaultTag | string | `"latest"` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/ssl-redirect" | string | `"true"` |  |

--- a/charts/common/README.md.gotmpl
+++ b/charts/common/README.md.gotmpl
@@ -31,6 +31,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | :----------- | :---------------- | :--------------------- | :-------------- |
 |logPersistence removed|8.0.0|Removes logPersistence functionality as it can be achieved with volumeMounts & extraVolumeClaimTemplates and is buggy anyway.|https://github.com/bedag/helm-charts/pull/68|
 |networkpolicy template changes|9.0.0|add possibility to define more than one Port in networkpolicy|https://github.com/bedag/helm-charts/pull/70|
+|networkpolicy template changes|10.0.0|add possibility to create multiple networkpolicies|https://github.com/bedag/helm-charts/pull/77|
 {{/*
   Chart Values
 */}}

--- a/charts/common/ci/values.test.yaml
+++ b/charts/common/ci/values.test.yaml
@@ -45,18 +45,21 @@ components:
     # start common.networkpolicy
     networkpolicies:
       networkpolicy-1:
-        deploy: true
         policyTypes:
           - Ingress
           - Egress
         ingress:
+          namespaceSelector:
+          - matchLabels:
+              kubernetes.io/metadata.name: namespace-1
           podSelector:
           - matchLabels:
-            app.kubernetes.io/component: component-2
+              app.kubernetes.io/component: component-2
         egress:
           namespaceSelector:
           - matchLabels:
-            kubernetes.io/metadata.name: namespace-1
+              kubernetes.io/metadata.name: namespace-1
+
     # end common.networkpolicy
     controller:
       deploy: true
@@ -145,7 +148,6 @@ components:
     # start common.networkpolicy
     networkpolicies:
       networkpolicy-1:
-        deploy: true
         policyTypes:
           - Ingress
         ingress:
@@ -222,15 +224,14 @@ components:
     # start common.networkpolicy
     networkpolicies:
       networkpolicy-1:
-        deploy: true
         policyTypes:
           - Ingress
         ingress:
           ports:
           - protocol: TCP
-            port: "8080"
+            port: 8080
           - protocol: TCP
-            port: "8081"
+            port: 8081
     # end common.networkpolicy
     controller:
       deploy: true

--- a/charts/common/ci/values.test.yaml
+++ b/charts/common/ci/values.test.yaml
@@ -43,11 +43,20 @@ components:
           - 10.0.0.0/8
     # end common.service
     # start common.networkpolicy
-    networkpolicy:
-      deploy: true
-      podSelector:
-      - matchLabels:
-          app.kubernetes.io/component: component-2
+    networkpolicies:
+      networkpolicy-1:
+        deploy: true
+        policyTypes:
+          - Ingress
+          - Egress
+        ingress:
+          podSelector:
+          - matchLabels:
+            app.kubernetes.io/component: component-2
+        egress:
+          namespaceSelector:
+          - matchLabels:
+            kubernetes.io/metadata.name: namespace-1
     # end common.networkpolicy
     controller:
       deploy: true
@@ -134,10 +143,14 @@ components:
         deploy: true
     # end common.service
     # start common.networkpolicy
-    networkpolicy:
-      deploy: true
-      ipBlock:
-        cidr: 0.0.0.0/0
+    networkpolicies:
+      networkpolicy-1:
+        deploy: true
+        policyTypes:
+          - Ingress
+        ingress:
+          ipBlock:
+            cidr: 0.0.0.0/0
     # end common.networkpolicy
     controller:
       deploy: true
@@ -207,13 +220,17 @@ components:
         deploy: true
     # end common.service
     # start common.networkpolicy
-    networkpolicy:
-      deploy: true
-      ingressPorts:
-      - protocol: TCP
-        port: "8080"
-      - protocol: TCP
-        port: "8081"
+    networkpolicies:
+      networkpolicy-1:
+        deploy: true
+        policyTypes:
+          - Ingress
+        ingress:
+          ports:
+          - protocol: TCP
+            port: "8080"
+          - protocol: TCP
+            port: "8081"
     # end common.networkpolicy
     controller:
       deploy: true
@@ -281,10 +298,6 @@ components:
       service-1:
         deploy: false
     # end common.service
-    # start common.networkpolicy
-    networkpolicy:
-      deploy: false
-    # end common.networkpolicy
 
     controller:
       deploy: true

--- a/charts/common/templates/_networkpolicy-sections.yaml
+++ b/charts/common/templates/_networkpolicy-sections.yaml
@@ -1,6 +1,5 @@
 {{- define "networkpolicy.sections" -}}
-{{- $section := .section }}
-
+{{- $section := . }}
 {{- if $section.ipBlock }}
 - ipBlock:
     cidr: {{ $section.ipBlock.cidr }}
@@ -30,7 +29,7 @@
 {{- if $section.ports }}
 ports:
 {{- with $section.ports }}
-{{- toYaml . | nindent 8 }}
+{{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/common/templates/_networkpolicy-sections.yaml
+++ b/charts/common/templates/_networkpolicy-sections.yaml
@@ -1,0 +1,36 @@
+{{- define "networkpolicy.sections" -}}
+{{- $section := .section }}
+
+{{- if $section.ipBlock }}
+- ipBlock:
+    cidr: {{ $section.ipBlock.cidr }}
+{{- end }}
+{{- if $section.namespaceSelector }}
+{{- range $section.namespaceSelector }}
+{{- if .matchLabels }}
+- namespaceSelector:
+    matchLabels:
+      {{- range $key, $val := .matchLabels }}
+      {{ $key }}: {{ $val | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $section.podSelector }}
+{{- range $section.podSelector }}
+{{- if .matchLabels }}
+- podSelector:
+    matchLabels:
+      {{- range $key, $val := .matchLabels }}
+      {{ $key }}: {{ $val | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $section.ports }}
+ports:
+{{- with $section.ports }}
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/common/templates/_networkpolicy.yaml
+++ b/charts/common/templates/_networkpolicy.yaml
@@ -19,7 +19,6 @@ spec:
 {{- range $name, $component := .Values.components }}
 {{- if $component.networkpolicies }}
 {{- range $networkpolicyname, $networkpolicy := $component.networkpolicies }}
-{{- if $networkpolicy.deploy }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -41,13 +40,14 @@ spec:
   {{- $section := $networkpolicy.ingress }}
   ingress:
     - from:
-      {{ include "networkpolicy.sections" $section | indent 6 }}
-  {{- else if $networkpolicy.egress }}
-  {{- $section := $networkpolicy.egress }}
-    - to:
-      {{ include "networkpolicy.sections" $section | indent 6 }}
+      {{- include "networkpolicy.sections" $section | indent 6 }}
   {{- end }}
-{{- end }}
+  {{- if $networkpolicy.egress }}
+  {{- $section := $networkpolicy.egress }}
+  egress:
+    - to:
+      {{- include "networkpolicy.sections" $section | indent 6 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/common/templates/_networkpolicy.yaml
+++ b/charts/common/templates/_networkpolicy.yaml
@@ -19,6 +19,7 @@ spec:
 {{- range $name, $component := .Values.components }}
 {{- if $component.networkpolicies }}
 {{- range $networkpolicyname, $networkpolicy := $component.networkpolicies }}
+{{- if $networkpolicy }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -48,6 +49,7 @@ spec:
     - to:
       {{- include "networkpolicy.sections" $section | indent 6 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/common/templates/_networkpolicy.yaml
+++ b/charts/common/templates/_networkpolicy.yaml
@@ -17,14 +17,14 @@ spec:
 
 {{- $root := . }}
 {{- range $name, $component := .Values.components }}
-{{- if $component.networkpolicy }}
-{{- $networkpolicy := $component.networkpolicy }}
+{{- if $component.networkpolicies }}
+{{- range $networkpolicyname, $networkpolicy := $component.networkpolicies }}
 {{- if $networkpolicy.deploy }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ template "library.name" $root }}-{{ $name }}
+  name: {{ template "library.name" $root }}-{{ $name }}-{{ $networkpolicyname }}
   labels:
 {{ include "library.labels.standard" $root | indent 4 }}
     app.kubernetes.io/component: {{ $name }}
@@ -34,30 +34,20 @@ spec:
       app.kubernetes.io/name: {{ template "library.name" $root }}
       app.kubernetes.io/component: {{ $name }}
   policyTypes:
-    - Ingress
+    {{- range $policytype := $networkpolicy.policyTypes }}
+    - {{ $policytype | quote }}
+    {{- end }}
+  {{- if $networkpolicy.ingress }}
+  {{- $section := $networkpolicy.ingress }}
   ingress:
     - from:
-      {{- if $networkpolicy.ipBlock }}
-      - ipBlock:
-          cidr: {{ $networkpolicy.ipBlock.cidr }}
-      {{- end }}
-      {{- if $networkpolicy.podSelector }}
-      {{- range $networkpolicy.podSelector }}
-      {{- if .matchLabels }}
-      - podSelector:
-          matchLabels:
-            {{- range $key, $val := .matchLabels }}
-            {{ $key }}: {{ $val | quote }}
-            {{- end }}
-      {{- end }}
-      {{- end }}
-      {{- end }}
-      {{- if $networkpolicy.ingressPorts }}
-      ports:
-      {{- with $networkpolicy.ingressPorts }}
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{ include "networkpolicy.sections" $section | indent 6 }}
+  {{- else if $networkpolicy.egress }}
+  {{- $section := $networkpolicy.egress }}
+    - to:
+      {{ include "networkpolicy.sections" $section | indent 6 }}
+  {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -119,7 +119,10 @@
                 "type": "string"
               },
               "containerPort": {
-                "type": "integer"
+                "type": [
+                  "number",
+                  "string"
+                ]
               }
             }
           }
@@ -274,6 +277,76 @@
         },
         "port": {
           "default": "http"
+        }
+      }
+    },
+    "networkpolicyType": {
+      "type": "object",
+      "properties": {
+        "ipBlock": {
+          "type": "object",
+          "required": [
+            "cidr"
+          ],
+          "properties": {
+            "cidr": {
+              "type": "string"
+            }
+          }
+        },
+        "namespaceSelector": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "patternProperties": {
+              "^.*$": {
+                "type": "object",
+                "patternProperties": {
+                  "^.*$": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "podSelector": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "patternProperties": {
+              "^.*$": {
+                "type": "object",
+                "patternProperties": {
+                  "^.*$": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "protocol": {
+                "type": "string",
+                "enum": [
+                  "TCP",
+                  "UDP",
+                  "SCTP"
+                ]
+              },
+              "port": {
+                "type": [
+                  "number",
+                  "string"
+                ]
+              }
+            }
+          }
         }
       }
     }
@@ -627,83 +700,17 @@
                   "type": "object",
                   "properties": {
                     "policyTypes": {
-                      "type": "array"
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": ["Ingress", "Egress"]
+                      }
                     },
                     "ingress": {
-                      "type": "object",
-                      "properties": {
-                        "ipBlock": {
-                          "type": "object",
-                          "required": [
-                            "cidr"
-                          ],
-                          "properties": {
-                            "cidr": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "ports": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "protocol",
-                              "port"
-                            ],
-                            "properties": {
-                              "protocol": {
-                                "type": "string",
-                                "default": "TCP",
-                                "enum": [
-                                  "TCP",
-                                  "UDP",
-                                  "SCTP"
-                                ]
-                              },
-                              "port": {
-                                "type": "integer"
-                              }
-                            }
-                          }
-                        }
-                      }
+                      "$ref": "#/$defs/networkpolicyType"
                     },
                     "egress": {
-                      "type": "object",
-                      "properties": {
-                        "ipBlock": {
-                          "type": "object",
-                          "required": [
-                            "cidr"
-                          ],
-                          "properties": {
-                            "cidr": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "ports": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "protocol": {
-                                "type": "string",
-                                "default": "TCP",
-                                "enum": [
-                                  "TCP",
-                                  "UDP",
-                                  "SCTP"
-                                ]
-                              },
-                              "port": {
-                                "type": "integer"
-                              }
-                            }
-                          }
-                        }
-                      }
+                      "$ref": "#/$defs/networkpolicyType"
                     }
                   }
                 }

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -625,12 +625,85 @@
               "patternProperties": {
                 "^.*$": {
                   "type": "object",
-                  "required": [
-                    "deploy"                  ],
                   "properties": {
-                    "deploy": {
-                      "type": "boolean",
-                      "default": false
+                    "policyTypes": {
+                      "type": "array"
+                    },
+                    "ingress": {
+                      "type": "object",
+                      "properties": {
+                        "ipBlock": {
+                          "type": "object",
+                          "required": [
+                            "cidr"
+                          ],
+                          "properties": {
+                            "cidr": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "ports": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "protocol",
+                              "port"
+                            ],
+                            "properties": {
+                              "protocol": {
+                                "type": "string",
+                                "default": "TCP",
+                                "enum": [
+                                  "TCP",
+                                  "UDP",
+                                  "SCTP"
+                                ]
+                              },
+                              "port": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "egress": {
+                      "type": "object",
+                      "properties": {
+                        "ipBlock": {
+                          "type": "object",
+                          "required": [
+                            "cidr"
+                          ],
+                          "properties": {
+                            "cidr": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "ports": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "protocol": {
+                                "type": "string",
+                                "default": "TCP",
+                                "enum": [
+                                  "TCP",
+                                  "UDP",
+                                  "SCTP"
+                                ]
+                              },
+                              "port": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -620,44 +620,17 @@
                 }
               }
             },
-            "networkpolicy": {
+            "networkpolicies": {
               "type": "object",
-              "required": [
-                "deploy"
-              ],
-              "properties": {
-                "deploy": {
-                  "type": "boolean",
-                  "default": false
-                },
-                "ipBlock": {
+              "patternProperties": {
+                "^.*$": {
                   "type": "object",
                   "required": [
-                    "cidr"
-                  ],
+                    "deploy"                  ],
                   "properties": {
-                    "cidr": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "ingressPorts": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "protocol": {
-                        "type": "string",
-                        "default": "TCP",
-                        "enum": [
-                          "TCP",
-                          "UDP",
-                          "SCTP"
-                        ]
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
+                    "deploy": {
+                      "type": "boolean",
+                      "default": false
                     }
                   }
                 }

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -207,59 +207,57 @@ components:
     # end common.service
     # start common.networkpolicy
     # networkpolicy allows access from outside of the namespace or from other pods
-    networkpolicies:
+    networkpolicies: {}
       # specify the name of the networkpolicy
-      networkpolicy-1:
-          # deploy has to be set to true for rendering to be applied
-          deploy: false
-          # List of policyTypes
-          #policyTypes:
-          #  - Ingress
-          #  - Egress
-          #
-          # Ingress rules
-          #ingress:
-            # Optional IP CIDR source ranges to allow ingress traffic from
-            #ipBlock:
-            #  cidr: "0.0.0.0/0"
-            # namespaceSelector is a optional list of matchLabels maps. This selects particular namespaces from which all Pods should be allowed to access the pods of this component.
-            #namespaceSelector:
-            #- matchLabels:
-            #    app.kubernetes.io/name: appname
-            #    app.kubernetes.io/component: component-1
-            # podSelector is a optional list of matchLabels maps. All pods (in the actual namespace) matching these labels are allowed to access the pods of this component.
-            #podSelector:
-            #- matchLabels:
-            #    app.kubernetes.io/name: appname
-            #    app.kubernetes.io/component: component-2
-            # Ports is a list of ports on which connections are allowed.
-            #ports:
-            #- protocol: TCP
-            #  port: 8080
-            #- protocol: TCP
-            #  port: 8081
-          #
-          # Egress rules
-          #egress:
-            # Optional IP CIDR destination ranges to allow egress traffic to
-            #ipBlock:
-            #  cidr: "0.0.0.0/0"
-            # namespaceSelector is a optional list of matchLabels maps. This selects particular namespaces to where the pods of this component are allowed to connect to.
-            #namespaceSelector:
-            #- matchLabels:
-            #    app.kubernetes.io/name: appname
-            #    app.kubernetes.io/component: component-1
-            # podSelector is a optional list of matchLabels maps. All pods that match these labels may be accessed by the pods of this component.
-            #podSelector:
-            #- matchLabels:
-            #    app.kubernetes.io/name: appname
-            #    app.kubernetes.io/component: component-2
-            # Ports is a list of destination ports (in the previously defined namespaces/pods) to where connections are allowed.
-            #ports:
-            #- protocol: TCP
-            #  port: 8080
-            #- protocol: TCP
-            #  port: 8081
+      #networkpolicy-1:
+        # List of policyTypes
+        #policyTypes:
+        #  - Ingress
+        #  - Egress
+        #
+        # Ingress rules
+        #ingress:
+          # Optional IP CIDR source ranges to allow ingress traffic from
+          #ipBlock:
+          #  cidr: "0.0.0.0/0"
+          # namespaceSelector is a optional list of matchLabels maps. This selects particular namespaces from which all Pods should be allowed to access the pods of this component.
+          #namespaceSelector:
+          #- matchLabels:
+          #    app.kubernetes.io/name: appname
+          #    app.kubernetes.io/component: component-1
+          # podSelector is a optional list of matchLabels maps. All pods (in the actual namespace) matching these labels are allowed to access the pods of this component.
+          #podSelector:
+          #- matchLabels:
+          #    app.kubernetes.io/name: appname
+          #    app.kubernetes.io/component: component-2
+          # Ports is a list of ports on which connections are allowed.
+          #ports:
+          #- protocol: TCP
+          #  port: 8080
+          #- protocol: TCP
+          #  port: 8081
+        #
+        # Egress rules
+        #egress:
+          # Optional IP CIDR destination ranges to allow egress traffic to
+          #ipBlock:
+          #  cidr: "0.0.0.0/0"
+          # namespaceSelector is a optional list of matchLabels maps. This selects particular namespaces to where the pods of this component are allowed to connect to.
+          #namespaceSelector:
+          #- matchLabels:
+          #    app.kubernetes.io/name: appname
+          #    app.kubernetes.io/component: component-1
+          # podSelector is a optional list of matchLabels maps. All pods that match these labels may be accessed by the pods of this component.
+          #podSelector:
+          #- matchLabels:
+          #    app.kubernetes.io/name: appname
+          #    app.kubernetes.io/component: component-2
+          # Ports is a list of destination ports (in the previously defined namespaces/pods) to where connections are allowed.
+          #ports:
+          #- protocol: TCP
+          #  port: 8080
+          #- protocol: TCP
+          #  port: 8081
     # end common.networkpolicy
 
     # controller is used for deploying pods via Deployment, StatefulSet, Job or CronJob ressources

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -207,23 +207,59 @@ components:
     # end common.service
     # start common.networkpolicy
     # networkpolicy allows access from outside of the namespace or from other pods
-    networkpolicy:
-      # deploy has to be set to true for rendering to be applied
-      deploy: false
-      # Optional IP CIDR source ranges to allow ingress traffic
-      # ipBlock:
-      #   cidr: "0.0.0.0/0"
-      # podSelector is a optional list of matchLabels maps. All pods matching the labels are allowed to access the pods of this component
-      # podSelector:
-      # - matchLabels:
-      #     app.kubernetes.io/name: appname
-      #     app.kubernetes.io/component: component-2
-      # ingressPorts is a list of ports on which connections are allowed
-      # ingressPorts:
-      # - protocol: TCP
-      #   port: 8080
-      # - protocol: TCP
-      #   port: 8081
+    networkpolicies:
+      # specify the name of the networkpolicy
+      networkpolicy-1:
+          # deploy has to be set to true for rendering to be applied
+          deploy: false
+          # List of policyTypes
+          #policyTypes:
+          #  - Ingress
+          #  - Egress
+          #
+          # Ingress rules
+          #ingress:
+            # Optional IP CIDR source ranges to allow ingress traffic from
+            #ipBlock:
+            #  cidr: "0.0.0.0/0"
+            # namespaceSelector is a optional list of matchLabels maps. This selects particular namespaces from which all Pods should be allowed to access the pods of this component.
+            #namespaceSelector:
+            #- matchLabels:
+            #    app.kubernetes.io/name: appname
+            #    app.kubernetes.io/component: component-1
+            # podSelector is a optional list of matchLabels maps. All pods (in the actual namespace) matching these labels are allowed to access the pods of this component.
+            #podSelector:
+            #- matchLabels:
+            #    app.kubernetes.io/name: appname
+            #    app.kubernetes.io/component: component-2
+            # Ports is a list of ports on which connections are allowed.
+            #ports:
+            #- protocol: TCP
+            #  port: 8080
+            #- protocol: TCP
+            #  port: 8081
+          #
+          # Egress rules
+          #egress:
+            # Optional IP CIDR destination ranges to allow egress traffic to
+            #ipBlock:
+            #  cidr: "0.0.0.0/0"
+            # namespaceSelector is a optional list of matchLabels maps. This selects particular namespaces to where the pods of this component are allowed to connect to.
+            #namespaceSelector:
+            #- matchLabels:
+            #    app.kubernetes.io/name: appname
+            #    app.kubernetes.io/component: component-1
+            # podSelector is a optional list of matchLabels maps. All pods that match these labels may be accessed by the pods of this component.
+            #podSelector:
+            #- matchLabels:
+            #    app.kubernetes.io/name: appname
+            #    app.kubernetes.io/component: component-2
+            # Ports is a list of destination ports (in the previously defined namespaces/pods) to where connections are allowed.
+            #ports:
+            #- protocol: TCP
+            #  port: 8080
+            #- protocol: TCP
+            #  port: 8081
     # end common.networkpolicy
 
     # controller is used for deploying pods via Deployment, StatefulSet, Job or CronJob ressources


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:
- Add the possibility to create multiple networkpolicies
- Add the possibility to use namespaceSelector in ingress and egress.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Notes for Reviewer**:


**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
