### PR TITLE
fix(vcluster): correctly template dockerconfig

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/templates/lifecycle/extra-manifests.yaml
+++ b/charts/vcluster/templates/lifecycle/extra-manifests.yaml
@@ -13,7 +13,7 @@ stringData:
   {{- if (include "pkg.images.registry.auth" $) }}
   regcred.yaml: |
     apiVersion: v1
-    data:
+    stringData:
       .dockerconfigjson: {{ include "pkg.images.dockerconfigjson" $ }}
     kind: Secret
     metadata:

--- a/charts/vcluster/templates/lifecycle/extra-manifests.yaml
+++ b/charts/vcluster/templates/lifecycle/extra-manifests.yaml
@@ -13,7 +13,7 @@ stringData:
   {{- if (include "pkg.images.registry.auth" $) }}
   regcred.yaml: |
     apiVersion: v1
-    stringData:
+    data:
       .dockerconfigjson: {{ include "pkg.images.dockerconfigjson" $ }}
     kind: Secret
     metadata:

--- a/charts/vcluster/templates/pkg/_images.tpl
+++ b/charts/vcluster/templates/pkg/_images.tpl
@@ -49,7 +49,7 @@ kube-system
 {{- define "pkg.images.dockerconfigjson" -}}
   {{- if and (include "pkg.images.registry.set" $) (include "pkg.images.registry.auth" $) -}}
     {{- $registry := $.Values.global.registry -}}
-    {{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" (include "pkg.images.registry.url" $) $registry.creds.username $registry.creds.password (default "" $registry.creds.email) (printf "%s:%s" .username .password | b64enc) | b64enc }}
+    {{- printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" (include "pkg.images.registry.url" $) (printf "%s:%s" $registry.creds.username $registry.creds.password | b64enc) | b64enc }}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:

creds.username and creds.password were never reachable, therefor both values were `nil`


**Checklist**:

- [ ] Pull Request title in format `[chart]: Changed Something`
- [ ] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [ ] Chart Version bumped
- [ ] All commits are signed-off
