### PR TITLE
[vcluster]: Add k8s apiserver probe resource

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 
@@ -90,7 +90,7 @@ Global Values
 | global.components.exposure.ingress.port | int | `443` | Port for Ingresses |
 | global.components.metrics | object | `{}` |  |
 | global.components.networkPolicy.enabled | bool | `false` | Enable NetworkPolicies |
-| global.components.networkPolicy.from | list | `[]` |  |
+| global.components.networkPolicy.from | list | `[]` | Add `from` block for networkPolicies (by default from anywhere) |
 | global.components.service.annotations | object | `{}` | Annotations for all services |
 | global.components.service.labels | object | `{}` | Labels for all services |
 | global.components.workloads.affinity | object | `{}` | Affinity for all workloads (Overwrites all workloads affinities) |
@@ -431,6 +431,22 @@ Deploys [Kubernetes API Server](https://kubernetes.io/docs/reference/command-lin
 | kubernetes.apiServer.ingress.ingressClassName | string | `""` | Ingressclass for all ingresses |
 | kubernetes.apiServer.injectProxy | bool | `false` | Inject Proxy as Environment Variables |
 | kubernetes.apiServer.labels | object | `{}` | Labels for Workload |
+| kubernetes.apiServer.metrics.probe.annotations | object | `{}` | Assign additional Annotations |
+| kubernetes.apiServer.metrics.probe.enabled | bool | `false` | Enable Probe |
+| kubernetes.apiServer.metrics.probe.interval | string | `""` | Probeing Interval |
+| kubernetes.apiServer.metrics.probe.jobName | string | `""` | Name of the scrape_job |
+| kubernetes.apiServer.metrics.probe.labels | object | `{}` | Assign additional labels according to Prometheus' probeSelector matching labels |
+| kubernetes.apiServer.metrics.probe.module | string | `""` | Module to use for the probeing |
+| kubernetes.apiServer.metrics.probe.namespace | string | `""` | Install the Probe into a different Namespace, as the monitoring stack one (default: the release one) |
+| kubernetes.apiServer.metrics.probe.prober | object | `{"path":"","proxyUrl":"","scheme":"","url":""}` | Prober Configuration |
+| kubernetes.apiServer.metrics.probe.prober.path | string | `""` | Prober path |
+| kubernetes.apiServer.metrics.probe.prober.proxyUrl | string | `""` | Optional Proxy URL |
+| kubernetes.apiServer.metrics.probe.prober.scheme | string | `""` | Scheme to use for Probing |
+| kubernetes.apiServer.metrics.probe.prober.url | string | `""` | URL to the Prober |
+| kubernetes.apiServer.metrics.probe.tlsConfig | object | `{}` | Probe tls Configuration |
+| kubernetes.apiServer.metrics.service.annotations | object | `{}` | Service Annotations |
+| kubernetes.apiServer.metrics.service.labels | object | `{}` | Service Labels |
+| kubernetes.apiServer.networkPolicy.from | list | `[]` | Add `from` block for networkPolicies (by default from anywhere) |
 | kubernetes.apiServer.nodeSelector | object | `{}` | Node Selector |
 | kubernetes.apiServer.podAnnotations | object | `{}` | Pod Annotations |
 | kubernetes.apiServer.podDisruptionBudget | object | `{}` | Configure PodDisruptionBudget |
@@ -692,6 +708,7 @@ The Konnectivity-Server is deployed alongside with the API-Server. It must be re
 | kubernetes.konnectivity.server.injectProxy | bool | `false` | Inject Proxy as Environment Variables |
 | kubernetes.konnectivity.server.labels | object | `{}` | Labels for Workload |
 | kubernetes.konnectivity.server.mode | string | `"GRPC"` | This controls the protocol between the API Server and the Konnectivity server. Supported values are "GRPC" and "HTTPConnect". "GRPC" will deploy konnectivity-server as a sidecar for apiserver. "HTTPConnect" will deploy konnectivity-server as separate deployment. |
+| kubernetes.konnectivity.server.networkPolicy.from | list | `[]` | Add `from` block for networkPolicies (by default from anywhere) |
 | kubernetes.konnectivity.server.nodeSelector | object | `{}` | Node Selector |
 | kubernetes.konnectivity.server.podAnnotations | object | `{}` | Pod Annotations |
 | kubernetes.konnectivity.server.podDisruptionBudget | object | `{}` | Configure PodDisruptionBudget |

--- a/charts/vcluster/templates/components/kubernetes/apiserver/probe.yaml
+++ b/charts/vcluster/templates/components/kubernetes/apiserver/probe.yaml
@@ -1,0 +1,46 @@
+{{- if (include "kubernetes.enabled" $) -}}
+  {{- $manifest := $.Values.kubernetes.apiServer -}}
+  {{- $fullName := include "kubernetes.fullname" . -}}
+  {{- $component_name := "apiServer" -}}
+  {{- if (include "pkg.components.metrics.enabled" (dict "metrics" $manifest.metrics "ctx" $)) -}}
+    {{- if (include "pkg.components.probe.enabled" (dict "sm" $manifest.metrics.probe "ctx" $)) -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: {{ $fullName }}-api-probe
+  namespace: {{ $manifest.metrics.probe.namespace | default .Release.Namespace }}
+  labels: {{- include "kubernetes.labels" $ | nindent 4 }}
+    {{ include "pkg.common.labels.component" $ }}: {{ $component_name }}
+    {{- with $manifest.metrics.probe.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $manifest.metrics.probe.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  jobName: {{ $manifest.metrics.probe.namespace | default "k8s-apiserver-probe" }}
+  interval: {{ $manifest.metrics.probe.interval | default "5s" }}
+  module: {{ $manifest.metrics.probe.module | default "http_2xx" }}
+  {{- with $manifest.metrics.probe.prober }}
+  prober:
+    url: {{ .url | default "blackbox-exporter-prometheus-blackbox-exporter:9115" }}
+    path: {{ .path | default "/probe" }}
+    scheme: {{ .scheme | default "http" }}
+    proxyUrl: {{ .proxyUrl | default ""}}
+  {{- end }}
+  targets:
+  staticConfig:
+    static:
+      {{- with (include "kubernetes.api.endpoint" $) }}
+      - {{ . }}
+      {{- end }}
+    labels:
+      cluster: {{ include "pkg.cluster.name" $ }}
+  {{- with $manifest.metrics.probe.tlsConfig }}
+  tlsConfig: {{- toYaml . | nindent 4 }}
+  {{- end }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/vcluster/templates/components/kubernetes/apiserver/probe.yaml
+++ b/charts/vcluster/templates/components/kubernetes/apiserver/probe.yaml
@@ -31,13 +31,13 @@ spec:
     proxyUrl: {{ .proxyUrl | default ""}}
   {{- end }}
   targets:
-  staticConfig:
-    static:
-      {{- with (include "kubernetes.api.endpoint" $) }}
-      - {{ . }}
-      {{- end }}
-    labels:
-      cluster: {{ include "pkg.cluster.name" $ }}
+    staticConfig:
+      static:
+        {{- with (include "kubernetes.api.endpoint" $) }}
+        - {{ . }}
+        {{- end }}
+      labels:
+        cluster: {{ include "pkg.cluster.name" $ }}
   {{- with $manifest.metrics.probe.tlsConfig }}
   tlsConfig: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/vcluster/templates/components/kubernetes/etcd/servicemonitor.yaml
+++ b/charts/vcluster/templates/components/kubernetes/etcd/servicemonitor.yaml
@@ -25,7 +25,7 @@ spec:
   - interval: {{ .interval }}
     port: http-metrics
     path: /metrics
-    scheme: https
+    scheme: http
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/charts/vcluster/templates/pkg/_components.tpl
+++ b/charts/vcluster/templates/pkg/_components.tpl
@@ -278,6 +278,22 @@ name: {{ default (include "vcluster.fullname" $) .name }}
 {{- end -}}
 
 {{/*
+    Components Metrics enabled
+*/}}
+{{- define "pkg.components.probe.enabled" -}}
+  {{- $components := $.ctx.Values.global.components -}}
+  {{- $sm := $.sm -}}
+  {{- if $components.metrics -}}
+    {{- if $components.metrics.probe -}}
+      {{- $sm = $components.metrics.probe -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $sm.enabled -}}
+    {{- true -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
     Components NetworkPolicies enabled
 */}}
 {{- define "pkg.components.netpol.enabled" -}}

--- a/charts/vcluster/values.yaml
+++ b/charts/vcluster/values.yaml
@@ -1414,6 +1414,44 @@ kubernetes:
       targetCPUUtilizationPercentage: 80
       # -- Benchmark Memory Usage
       targetMemoryUtilizationPercentage:
+    
+    # API Server Metrics Configuration
+    metrics:
+      enabled: false
+      # Metrics Service
+      service:
+        # -- Service Labels
+        labels: {}
+        # -- Service Annotations
+        annotations: {}
+      # Probe ( needs external prober e.g. blackbox-exporter )
+      probe:
+        # -- Enable Probe
+        enabled: false
+        # -- Install the Probe into a different Namespace, as the monitoring stack one (default: the release one)
+        namespace: ''
+        # -- Name of the scrape_job
+        jobName: ''
+        # -- Probeing Interval
+        interval: ''
+        # -- Module to use for the probeing
+        module: ''
+        # -- Prober Configuration
+        prober:
+          # -- URL to the Prober
+          url: ''
+          # -- Scheme to use for Probing
+          scheme: ''
+          # -- Prober path
+          path: ''
+          # -- Optional Proxy URL
+          proxyUrl: ''
+        # -- Probe tls Configuration
+        tlsConfig: {}
+        # -- Assign additional labels according to Prometheus' probeSelector matching labels
+        labels: {}
+        # -- Assign additional Annotations
+        annotations: {}
 
   controllerManager:
     # -- Enable Kubernetes Controller-Manager

--- a/charts/vcluster/values.yaml
+++ b/charts/vcluster/values.yaml
@@ -91,10 +91,10 @@ global:
     networkPolicy:
       # -- Enable NetworkPolicies
       enabled: false
-      # -- Add `from` block for networkPolicies (by default from anywhere)
+      # -- Add `from` block for networkPolicies (by default from anywhere)
       from: []
-      # - ipBlock:
-      #     cidr: 192.168.0.0/24
+      # - ipBlock:
+      #     cidr: 192.168.0.0/24
 
     # Components Exposure
     exposure:
@@ -1397,10 +1397,10 @@ kubernetes:
 
     # NetworkPolicies Configuration
     networkPolicy:
-      # -- Add `from` block for networkPolicies (by default from anywhere)
+      # -- Add `from` block for networkPolicies (by default from anywhere)
       from: []
-      # - ipBlock:
-      #     cidr: 192.168.0.0/24
+      # - ipBlock:
+      #     cidr: 192.168.0.0/24
 
     # Autoscaler Configuration
     autoscaling:
@@ -1414,7 +1414,7 @@ kubernetes:
       targetCPUUtilizationPercentage: 80
       # -- Benchmark Memory Usage
       targetMemoryUtilizationPercentage:
-    
+
     # API Server Metrics Configuration
     metrics:
       enabled: false
@@ -1989,10 +1989,10 @@ kubernetes:
 
       # NetworkPolicies Configuration
       networkPolicy:
-        # -- Add `from` block for networkPolicies (by default from anywhere)
+        # -- Add `from` block for networkPolicies (by default from anywhere)
         from: []
-        # - ipBlock:
-        #     cidr: 192.168.0.0/24
+        # - ipBlock:
+        #     cidr: 192.168.0.0/24
 
     # Konnectivity Agent
     agent:


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:

This PR adds the possibility to create a Probe resource for the k8s apiserver, which allows to monitor if the apiserver is responding as expected

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
- 
**Notes for Reviewer**:


**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
