### PR TITLE
[common]: Make pullSecret configurable

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 10.7.0
+version: 10.8.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 10.7.0](https://img.shields.io/badge/Version-10.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 10.8.0](https://img.shields.io/badge/Version-10.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/templates/_pod.yaml
+++ b/charts/common/templates/_pod.yaml
@@ -146,9 +146,13 @@ tolerations:
 {{- if $root.Values.secrets }}
 {{- if $root.Values.secrets.data }}
 {{- if $root.Values.secrets.data.registry }}
-{{- if $root.Values.secrets.data.registry.pullSecret }}
+{{- if $root.Values.secrets.data.registry.pullSecret.enabled }}
 imagePullSecrets:
+{{- if $root.Values.secrets.data.registry.pullSecret.name }}
+  - name: {{ $root.Values.secrets.data.registry.pullSecret.name }}
+{{- else }}
   - name: {{ template "library.name" $root }}-registry-pull-secret
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -384,7 +384,19 @@
               ],
               "properties": {
                 "pullSecret": {
-                  "type": "boolean"
+                  "type": "object",
+                  "required": [
+                    "enabled"
+                  ],
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -16,12 +16,16 @@ defaultTag: latest
 # timezone to set as environment variable 'TZ' in each pod. Comment out for using default ("Europe/Zurich")
 # timezone: "Europe/Zurich"
 
-# secrets contains the pullSecret for the container registry to pull images. Set to 'true' to use a pullSecret.
-# The secret name consists of the 'library.name' variable and the suffix '-registry-pull-secret'.
+# secrets contains the pullSecret for the container registry to pull images. Set 'enabled' to 'true' to use a pullSecret.
+# The secret name consists of the 'library.name' variable and the suffix '-registry-pull-secret' if 'name' is not specified.
 secrets:
   data:
     registry:
-      pullSecret: false
+      pullSecret:
+        # enabled activates the imagePullSecrets in the pod spec
+        enabled: false
+        # name is optional to override the default name, if omitted uses '{{ template "library.name" $root }}-registry-pull-secret'
+        # name: example-foo
 
 # start common.networkpolicy
 # -- networkpolicy restricts all access between the pods. To configure allowed connections, go to components.*.networkpolicy.podSelector


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:

Makes the pullSecret configurable in order to use the same secret for multiple common helm chart instances.

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
