### PR TITLE
[vcluster]: Removing variable 'KUBERNETES_SERVICE_HOST' from no_proxy

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/templates/pkg/_common.tpl
+++ b/charts/vcluster/templates/pkg/_common.tpl
@@ -96,7 +96,7 @@ Common Selector Labels
     {{- $no_proxy = ($no_proxy | trimSuffix ",") -}}
 
     {{/* Standard Stuff */}}
-    {{- $no_proxy = printf "%s,%s,.%s" $no_proxy "localhost,127.0.0.1,.svc,svc.,$KUBERNETES_SERVICE_HOST" ($.Release.Namespace | trimAll ".") -}}
+    {{- $no_proxy = printf "%s,%s,.%s" $no_proxy "localhost,127.0.0.1,.svc,svc." ($.Release.Namespace | trimAll ".") -}}
 
     {{/* Kubernetes Component */}}
     {{- if (include "kubernetes.enabled" $) -}}


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:

Removes the bash variable KUBERNETES_SERVICE_HOST from the no_proxy construct, which is causing issue with machine-controller / osn

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Notes for Reviewer**:


**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
