### PR TITLE
[common]: fix duplicated init container

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 10.10.1
+version: 10.10.2
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 10.10.1](https://img.shields.io/badge/Version-10.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 10.10.2](https://img.shields.io/badge/Version-10.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/ci/values.test.yaml
+++ b/charts/common/ci/values.test.yaml
@@ -155,6 +155,12 @@ components:
               mountPath: /opt/my-binary-license
               content: 'base64 encoded data'
           resources: {}
+      initContainers:
+        init-container-1:
+          image:
+            repository: db-init
+            tag: "latest"
+          resources: {}
   component-2:
     # start common.service
     services:

--- a/charts/common/templates/_binaryfiles.yaml
+++ b/charts/common/templates/_binaryfiles.yaml
@@ -4,7 +4,7 @@
 {{- if $componentValues.controller }}
 {{- if $componentValues.controller.deploy }}
 {{- if or $componentValues.controller.containers $componentValues.controller.initContainers }}
-{{- $containers := merge ($componentValues.controller.containers | default dict) ($componentValues.controller.initContainers | default dict) }}
+{{- $containers := merge (dict) ($componentValues.controller.containers | default dict) ($componentValues.controller.initContainers | default dict) }}
 {{- range $containerName, $containerValues := $containers }}
 {{- $configBinarys := $containerValues.binaryFiles }}
 {{- if $configBinarys }}

--- a/charts/common/templates/_configfiles.yaml
+++ b/charts/common/templates/_configfiles.yaml
@@ -30,7 +30,7 @@ Sensitive configs goes inside a Secret and non-sensitive configs are put in a Co
 {{- if $componentValues.controller }}
 {{- if $componentValues.controller.deploy }}
 {{- if or $componentValues.controller.containers $componentValues.controller.initContainers }}
-{{- $containers := merge ($componentValues.controller.containers | default dict) ($componentValues.controller.initContainers | default dict) }}
+{{- $containers := merge (dict) ($componentValues.controller.containers | default dict) ($componentValues.controller.initContainers | default dict) }}
 {{- range $containerName, $containerValues := $containers }}
 {{- $configFiles := $containerValues.configFiles }}
 {{- if $configFiles }}

--- a/charts/common/templates/_configmap.yaml
+++ b/charts/common/templates/_configmap.yaml
@@ -19,7 +19,7 @@ data:
 {{- end }}
 {{- end }}
 {{- if or $componentValues.controller.containers $componentValues.controller.initContainers }}
-{{- $containers := merge ($componentValues.controller.containers | default dict) ($componentValues.controller.initContainers | default dict) }}
+{{- $containers := merge (dict) ($componentValues.controller.containers | default dict) ($componentValues.controller.initContainers | default dict) }}
 {{- range $containerName, $containerValues := $containers }}
 {{- $configMap := $containerValues.envConfigMap }}
 {{- if $configMap }}

--- a/charts/common/templates/_deployment.yaml
+++ b/charts/common/templates/_deployment.yaml
@@ -54,7 +54,7 @@ spec:
         {{ .key }}: {{ include (print $.Template.BasePath .checksumFrom) $root | sha256sum }}
         {{- end }}
         {{- if or $deployment.containers $deployment.initContainers }}
-        {{- $containers := merge ($deployment.containers | default dict) ($deployment.initContainers | default dict) }}
+        {{- $containers := merge (dict) ($deployment.containers | default dict) ($deployment.initContainers | default dict) }}
         {{- range $containerName, $containerValues := $containers }}
         {{- $configMap := $containerValues.envConfigMap }}
         {{- if and $configMap (not $deployment.disableChecksumAnnotations) }}

--- a/charts/common/templates/_pod.yaml
+++ b/charts/common/templates/_pod.yaml
@@ -106,7 +106,7 @@ volumes:
   {{- end }}
   {{- end }}
   {{- if or $controllerValues.containers $controllerValues.initContainers }}
-  {{- $containers := merge ($controllerValues.containers | default dict) ($controllerValues.initContainers | default dict) }}
+  {{- $containers := merge (dict) ($controllerValues.containers | default dict) ($controllerValues.initContainers | default dict) }}
   {{- range $containerName, $containerValues := $containers }}
   {{- $configFiles := $containerValues.configFiles }}
   {{- if $configFiles }}

--- a/charts/common/templates/_secret.yaml
+++ b/charts/common/templates/_secret.yaml
@@ -20,7 +20,7 @@ data:
 {{- end }}
 {{- end }}
 {{- if or $componentValues.controller.containers $componentValues.controller.initContainers }}
-{{- $containers := merge ($componentValues.controller.containers | default dict) ($componentValues.controller.initContainers | default dict) }}
+{{- $containers := merge (dict) ($componentValues.controller.containers | default dict) ($componentValues.controller.initContainers | default dict) }}
 {{- range $containerName, $containerValues := $containers }}
 {{- $secret := $containerValues.envSecret }}
 {{- if $secret }}

--- a/charts/common/templates/_statefulset.yaml
+++ b/charts/common/templates/_statefulset.yaml
@@ -44,7 +44,8 @@ spec:
         {{ .key }}: {{ include (print $.Template.BasePath .checksumFrom) $root | sha256sum }}
         {{- end }}
         {{- if or $statefulset.containers $statefulset.initContainers }}
-        {{- range $containerName, $containerValues := merge ($statefulset.containers | default dict) ($statefulset.initContaineris | default dict) }}
+        {{- $containers := merge (dict) ($statefulset.containers | default dict) ($statefulset.initContainers | default dict) }}
+        {{- range $containerName, $containerValues := $containers }}
         {{- $configMap := $containerValues.envConfigMap }}
         {{- if and $configMap (not $statefulset.disableChecksumAnnotations) }}
         checksum/envConfigMap: {{ print $configMap | sha256sum }}

--- a/charts/common/templates/_statefulset.yaml
+++ b/charts/common/templates/_statefulset.yaml
@@ -44,8 +44,7 @@ spec:
         {{ .key }}: {{ include (print $.Template.BasePath .checksumFrom) $root | sha256sum }}
         {{- end }}
         {{- if or $statefulset.containers $statefulset.initContainers }}
-        {{- $containers := merge ($statefulset.containers | default dict) ($statefulset.initContainers | default dict) }}
-        {{- range $containerName, $containerValues := $containers }}
+        {{- range $containerName, $containerValues := merge ($statefulset.containers | default dict) ($statefulset.initContaineris | default dict) }}
         {{- $configMap := $containerValues.envConfigMap }}
         {{- if and $configMap (not $statefulset.disableChecksumAnnotations) }}
         checksum/envConfigMap: {{ print $configMap | sha256sum }}


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:
According to sprig documentation, our merge was used wrong way.  
Sprig documentation: https://github.com/Masterminds/sprig/blob/master/docs/dicts.md#merge-mustmerge  

**Which issue this PR fixes**
With this merge, we fix issues resulting from InitContainer being merged into Containers (ie. InitContainers appear twice)  
fixes #123 

**Notes for Reviewer**:

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
