### PR TITLE
[common]: Add scrapeTimeout to serviceMonitor endpoints & fix inclusion of components

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 10.10.2
+version: 10.11.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 10.10.2](https://img.shields.io/badge/Version-10.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 10.11.0](https://img.shields.io/badge/Version-10.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/templates/_servicemonitor-servicemonitor.yaml
+++ b/charts/common/templates/_servicemonitor-servicemonitor.yaml
@@ -19,6 +19,9 @@ spec:
   endpoints:
   - path: {{ .path | default "/metrics" }}
     interval: {{ .interval | default "30s" }}
+    {{- if .scrapeTimeout }}
+    scrapeTimeout: {{ .scrapeTimeout }}
+    {{- end }}
     port: {{ .port | default "http" }}
     {{- if $root.Values.servicemonitor.basicAuth.enabled }}
     basicAuth:

--- a/charts/common/templates/includes.yaml
+++ b/charts/common/templates/includes.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.deploy }}
+{{- if .Values.includes.ingress }}
   {{- template "common.ingress.ingress" . }}
   {{- template "common.ingress.secret" . }}
 {{- end }}
@@ -47,12 +47,12 @@
   {{- template "common.pvcs" . }}
 {{- end -}}
 
-{{- if .Values.servicemonitor.deploy }}
+{{- if .Values.includes.servicemonitor }}
   {{- template "common.servicemonitor.headless.service" . }}
   {{- template "common.servicemonitor.servicemonitor" . }}
   {{- template "common.servicemonitor.secret" . }}
 {{- end -}}
 
-{{- if .Values.servicemonitor.deploy }}
+{{- if .Values.includes.networkpolicy }}
   {{- template "common.networkpolicy" . }}
 {{- end -}}

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -271,6 +271,9 @@
           "type": "string",
           "default": "30s"
         },
+        "scrapeTimeout": {
+          "type": "string"
+        },
         "overrideUserKey": {
           "type": "string"
         },
@@ -371,25 +374,27 @@
     "includes": {
       "type": "object",
       "required": [
-        "networkpolicy",
-        "deployment",
-        "statefulset",
+        "ingress",
         "service",
+        "statefulset",
+        "deployment",
+        "job",
+        "cronjob",
         "envSecret",
         "envConfigMap",
-        "files",
         "configFiles",
         "binaryFiles",
+        "files",
         "pvcs",
-        "job",
-        "cronjob"
+        "servicemonitor",
+        "networkpolicy"
       ],
       "properties": {
-        "networkpolicy": {
+        "ingress": {
           "type": "boolean",
           "default": false
         },
-        "deployment": {
+        "service": {
           "type": "boolean",
           "default": false
         },
@@ -397,7 +402,15 @@
           "type": "boolean",
           "default": false
         },
-        "service": {
+        "deployment": {
+          "type": "boolean",
+          "default": false
+        },
+        "job": {
+          "type": "boolean",
+          "default": false
+        },
+        "cronjob": {
           "type": "boolean",
           "default": false
         },
@@ -409,10 +422,6 @@
           "type": "boolean",
           "default": false
         },
-        "files": {
-          "type": "boolean",
-          "default": false
-        },
         "configFiles": {
           "type": "boolean",
           "default": false
@@ -421,15 +430,19 @@
           "type": "boolean",
           "default": false
         },
+        "files": {
+          "type": "boolean",
+          "default": false
+        },
         "pvcs": {
           "type": "boolean",
           "default": false
         },
-        "job": {
+        "servicemonitor": {
           "type": "boolean",
           "default": false
         },
-        "cronjob": {
+        "networkpolicy": {
           "type": "boolean",
           "default": false
         }

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -15,19 +15,21 @@ defaultTag: latest
 
 # includes is used to include the desired template functions (see templates/includes.yaml)
 includes:
-  networkpolicy: false
-  deployment: false
-  statefulset: false
+  ingress: false
   service: false
-  envSecret: false
-  envConfigMap: false
-  # files is needed for mounted volumes (secrets or configmaps)
-  files: false
-  configFiles: false
-  binaryFiles: false
-  pvcs: false
+  statefulset: false
+  deployment: false
   job: false
   cronjob: false
+  envSecret: false
+  envConfigMap: false
+  configFiles: false
+  binaryFiles: false
+  # files is needed for mounted volumes (secrets or configmaps)
+  files: false
+  pvcs: false
+  servicemonitor: false
+  networkpolicy: false
 
 # timezone to set as environment variable 'TZ' in each pod. Comment out for using default ("Europe/Zurich")
 # timezone: "Europe/Zurich"
@@ -164,6 +166,8 @@ servicemonitor:
       # path: /metrics
       # interval sets the scrape interval. Comment out for using default ("30s")
       # interval: 30s
+      # scrapeTimeout sets the scrape timeout. Comment out for using default (global timeout of your prometheus)
+      # scrapeTimeout: 30s
       # port is used for matching the headless service. Comment out for using default ("http")
       # port: http
     # custom-komponente is a sample endpoint


### PR DESCRIPTION
**What this PR does**:

* Add new spec for setting the `scrapeTimeout` in a serviceMonitor endpoint
* Fix/change includes

**Notes for Reviewer**:


**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
