### PR TITLE
[vcluster]: fix some etcd backup job values werde not intended correctly

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.5.4
+version: 0.5.5
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/templates/components/kubernetes/etcd/backup-job.yaml
+++ b/charts/vcluster/templates/components/kubernetes/etcd/backup-job.yaml
@@ -46,16 +46,16 @@ spec:
             {{- include "pkg.components.pod_annotations" (dict "annotations" $kubernetes.etcd.backup.podAnnotations "ctx" $) | nindent 12 }}
         spec:
           {{- with (include "pkg.components.nodeselector" (dict "nodeSelector" $kubernetes.etcd.backup.nodeSelector "ctx" $)) }}
-          nodeSelector: {{- . | nindent 10 }}
+          nodeSelector: {{- . | nindent 12 }}
           {{- end }}
           {{- with (include "pkg.components.tolerations" (dict "tolerations" $kubernetes.etcd.backup.tolerations "ctx" $)) }}
-          tolerations:  {{- . | nindent 10 }}
+          tolerations:  {{- . | nindent 12 }}
           {{- end }}
           {{- with (include "pkg.components.priorityClass" (dict "pc" $kubernetes.etcd.backup.priorityClassName "ctx" $)) }}
           priorityClassName: {{ . }}
           {{- end }}
           {{- with (include "pkg.components.topologySpreadConstraints" (dict "tsc" $kubernetes.etcd.backup.topologySpreadConstraints "ctx" $)) }}
-          topologySpreadConstraints: {{ . | nindent 10 }}
+          topologySpreadConstraints: {{ . | nindent 12 }}
           {{- end }}
           affinity:
           {{- with (include "pkg.components.affinity" (dict "affinity" $kubernetes.etcd.backup.affinity "ctx" $)) }}


### PR DESCRIPTION
**What this PR does**:

The indentation for some values is wrong for the etcd backup job.  
This PR fixes these

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
