### PR TITLE
[vcluster]: delete uds file if it already exists when starting kon…

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.5.5
+version: 0.5.6
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.6](https://img.shields.io/badge/Version-0.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/templates/components/kubernetes/_templates.tpl
+++ b/charts/vcluster/templates/components/kubernetes/_templates.tpl
@@ -144,6 +144,7 @@ Template for konnectivityServer containers
   {{- else }}
   - --mode=grpc
   - --uds-name=/run/konnectivity-server/konnectivity-server.socket
+  - --delete-existing-uds-file=true
   - --server-port=0
   {{- end }}
   - --agent-port={{ $kubernetes.konnectivity.server.ports.agent }}


### PR DESCRIPTION
**What this PR does**:

The defined version (v0.0.37) of [apiserver-network-proxy](https://github.com/kubernetes-sigs/apiserver-network-proxy) doesn't delete the uds file prior to starting the konnectivity-server by default.
Newer versions have this flag enabled by default.

For now, we manually enable this flag.

ref: https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/476

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off