### PR TITLE
[vcluster]: Template empty string instead of nil

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.5.6
+version: 0.5.7
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.5.6](https://img.shields.io/badge/Version-0.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.7](https://img.shields.io/badge/Version-0.5.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/templates/components/kubernetes/apiserver/probe.yaml
+++ b/charts/vcluster/templates/components/kubernetes/apiserver/probe.yaml
@@ -28,7 +28,7 @@ spec:
     url: {{ .url | default "blackbox-exporter-prometheus-blackbox-exporter:9115" }}
     path: {{ .path | default "/probe" }}
     scheme: {{ .scheme | default "http" }}
-    proxyUrl: {{ .proxyUrl | default ""}}
+    proxyUrl: {{ .proxyUrl | default "" | quote }}
   {{- end }}
   targets:
     staticConfig:


### PR DESCRIPTION
**What this PR does**:

Currently when enabling probes for the apiServer, the value for proxyUrl is `nil` instead of an empty string.

```
kubectl explain probes.monitoring.coreos.com.spec.prober.proxyUrl
GROUP:      monitoring.coreos.com
KIND:       Probe
VERSION:    v1

FIELD: proxyUrl <string>

DESCRIPTION:
    Optional ProxyURL.
```

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
