### PR TITLE
[common]: enable host aliases in common chart

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 10.11.1
+version: 10.12.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 10.11.0
+version: 10.11.1
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 10.11.1](https://img.shields.io/badge/Version-10.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 10.12.0](https://img.shields.io/badge/Version-10.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 10.11.0](https://img.shields.io/badge/Version-10.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 10.11.1](https://img.shields.io/badge/Version-10.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/ci/values.test.yaml
+++ b/charts/common/ci/values.test.yaml
@@ -80,7 +80,15 @@ components:
     controller:
       deploy: true
       type: "Deployment"
-
+      hostAliases:
+      - ip: "127.0.0.1"
+        hostnames:
+        - "foo.local"
+        - "bar.local"
+      - ip: "10.1.2.3"
+        hostnames:
+        - "foo.remote"
+        - "bar.remote"
       containers:
         container-1:
           image:
@@ -208,6 +216,15 @@ components:
           volumeAttributes:
             secretProviderClass: "azure-kvname"
 
+      hostAliases:
+      - ip: "127.0.0.1"
+        hostnames:
+        - "foo.local"
+        - "bar.local"
+      - ip: "10.1.2.3"
+        hostnames:
+        - "foo.remote"
+        - "bar.remote"
       containers:
         container-1:
           image:
@@ -285,6 +302,16 @@ components:
         runAsNonRoot: true
         runAsUser: 1001
 
+      hostAliases:
+      - ip: "127.0.0.1"
+        hostnames:
+        - "foo.local"
+        - "bar.local"
+      - ip: "10.1.2.3"
+        hostnames:
+        - "foo.remote"
+        - "bar.remote"
+
       # start containers
       # dictionary of containers in a pod
       containers:
@@ -344,6 +371,16 @@ components:
         runAsGroup: 1001
         runAsNonRoot: true
         runAsUser: 1001
+
+      hostAliases:
+      - ip: "127.0.0.1"
+        hostnames:
+        - "foo.local"
+        - "bar.local"
+      - ip: "10.1.2.3"
+        hostnames:
+        - "foo.remote"
+        - "bar.remote"
 
       # start containers
       # dictionary of containers in a pod

--- a/charts/common/ci/values.test.yaml
+++ b/charts/common/ci/values.test.yaml
@@ -89,6 +89,7 @@ components:
         hostnames:
         - "foo.remote"
         - "bar.remote"
+
       containers:
         container-1:
           image:

--- a/charts/common/templates/_pod.yaml
+++ b/charts/common/templates/_pod.yaml
@@ -19,6 +19,13 @@ Distinguish between sensitive and non-sensitive config, first initialize empty d
   {{- end }}
 {{- end }}
 
+{{- if $controllerValues.hostAliases }}
+hostAliases:
+  {{- with $controllerValues.hostAliases }}
+  {{- toYaml . | nindent 2 }}
+  {{- end -}}
+{{- end }}
+
 {{- if $controllerValues.serviceAccountName }}
 serviceAccountName: {{ $controllerValues.serviceAccountName | quote }}
 {{- end }}

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -1090,6 +1090,24 @@
                     ]
                   }
                 },
+                "hostAliases": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      },
+                      "hostnames": {
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "ip",
+                      "hostnames"
+                    ]
+                  }
+                },
                 "containers": {
                   "type": "object",
                   "patternProperties": {

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -502,6 +502,14 @@ components:
       # hostAliases defines host names for IP addresses
       # see also https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases
       # hostAliases: {}
+      # - ip: "127.0.0.1"
+      #   hostnames:
+      #   - "foo.local"
+      #   - "bar.local"
+      # - ip: "10.1.2.3"
+      #   hostnames:
+      #   - "foo.remote"
+      #   - "bar.remote"
 
       # start containers
       # dictionary of containers in a pod

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -499,6 +499,10 @@ components:
       #   END ONLY FOR CSI
       # end pod
 
+      # hostAliases defines host names for IP addresses
+      # see also https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases
+      # hostAliases: {}
+
       # start containers
       # dictionary of containers in a pod
       containers: {}


### PR DESCRIPTION
**What this PR does**:

- Adds option to  [Adding entries to Pod /etc/hosts with HostAliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
