### PR TITLE
[common]: make clusterIP independent of LoadBalancer

### DIFF
--- a/charts/common/templates/_service.yaml
+++ b/charts/common/templates/_service.yaml
@@ -21,15 +21,15 @@ spec:
   {{- if $service.loadBalancerClass }}
   loadBalancerClass: {{ $service.loadBalancerClass }}
   {{- end }}
-  {{- if $service.clusterIP }}
-  clusterIP: {{ . }}
-  {{- end }}
   {{- if $service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
   {{- with $service.loadBalancerSourceRanges }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+  {{- end }}
+  {{- if $service.clusterIP }}
+  clusterIP: {{ . }}
   {{- end }}
   ports:
     - name: {{ $service.name | default "http" }}


### PR DESCRIPTION
**What this PR does**:
This allows headless services (i.e.: setting ClusterIP: None for non-LoadBalancer types)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Notes for Reviewer**:
Test compatibility with existing charts

**Checklist**:

- [ ] Pull Request title in format `[chart]: Changed Something`
- [ ] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [ ] Chart Version bumped
- [ ] All commits are signed-off
