### PR TITLE
[vcluster]: add release name to audit logs as prefix

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/templates/components/kubernetes/apiserver/deployment.yaml
+++ b/charts/vcluster/templates/components/kubernetes/apiserver/deployment.yaml
@@ -113,7 +113,7 @@ spec:
         {{- end }}
         {{- if $kubernetes.apiServer.audit.enabled }}
         - --audit-policy-file=/etc/kubernetes/audit/policy.yaml
-        - --audit-log-path=/var/log/kubernetes/audit/audit.log
+        - --audit-log-path=/var/log/kubernetes/audit/{{ include "pkg.cluster.name" $ }}-audit.log
         - --audit-log-maxage={{ $kubernetes.apiServer.audit.maxAge | int }}
         - --audit-log-maxbackup={{ $kubernetes.apiServer.audit.maxBackup | int }}
         - --audit-log-maxsize={{ $kubernetes.apiServer.audit.maxSize | int }}


### PR DESCRIPTION
**What this PR does**:

Adds the release name as a prefix to the audit logs in case multiple vclusters are running on the same node in order to avoid writing to the same file.

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
