### PR TITLE
[common]: support for defining multiple hosts for an Ingress

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 11.0.0
+version: 12.0.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 11.0.0](https://img.shields.io/badge/Version-11.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 12.0.0](https://img.shields.io/badge/Version-12.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 
@@ -24,6 +24,7 @@ Major Changes to functions are documented with the version affected. **Before up
 |networkpolicy template changes|9.0.0|add possibility to define more than one Port in networkpolicy|https://github.com/bedag/helm-charts/pull/70|
 |networkpolicy template changes|10.0.0|add possibility to create multiple networkpolicies|https://github.com/bedag/helm-charts/pull/77|
 |ingress template changes|11.0.0|add possibility to create multiple ingress objects|https://github.com/bedag/helm-charts/pull/134
+|ingress template changes|12.0.0|support defining multiple hosts and secrets for one ingress|
 
 # Values by Component
 
@@ -35,8 +36,8 @@ Major Changes to functions are documented with the version affected. **Before up
 | ingresses.ingress-1.annotations."nginx.ingress.kubernetes.io/ssl-redirect" | string | `"true"` | nginx.ingress.kubernetes.io/ssl-redirect needs to be set to 'true' when using SSL/TLS offloading with a LB outside of Kubernetes |
 | ingresses.ingress-1.deploy | bool | `false` | deploy has to be set to true for rendering to be applied |
 | ingresses.ingress-1.ingressClassName | string | `""` | ingressClassName, defines the class of the ingress controller. |
-| ingresses.ingress-1.rules | list | `[{"host":"myapp.cluster.local","http":{"paths":[{"backend":{"serviceNameSuffix":"component-1","servicePort":"http"},"path":"/","pathType":"ImplementationSpecific"}]}}]` | rules is a list of host rules used to configure the Ingress |
-| ingresses.ingress-1.rules[0] | object | `{"host":"myapp.cluster.local","http":{"paths":[{"backend":{"serviceNameSuffix":"component-1","servicePort":"http"},"path":"/","pathType":"ImplementationSpecific"}]}}` | host is the URL which ingress is listening |
+| ingresses.ingress-1.rules | list | `[{"host":"myapp.cluster.local","http":{"paths":[{"backend":{"serviceNameSuffix":"component-1","servicePort":"http"},"path":"/","pathType":"ImplementationSpecific"}]},"secretName":""}]` | rules is a list of host rules used to configure the Ingress |
+| ingresses.ingress-1.rules[0] | object | `{"host":"myapp.cluster.local","http":{"paths":[{"backend":{"serviceNameSuffix":"component-1","servicePort":"http"},"path":"/","pathType":"ImplementationSpecific"}]},"secretName":""}` | host is the URL which ingress is listening |
 | ingresses.ingress-1.rules[0].http | object | `{"paths":[{"backend":{"serviceNameSuffix":"component-1","servicePort":"http"},"path":"/","pathType":"ImplementationSpecific"}]}` | http is a list of http selectors pointing to backends |
 | ingresses.ingress-1.rules[0].http.paths | list | `[{"backend":{"serviceNameSuffix":"component-1","servicePort":"http"},"path":"/","pathType":"ImplementationSpecific"}]` | paths is a list of paths that map requests to backends |
 | ingresses.ingress-1.rules[0].http.paths[0] | object | `{"backend":{"serviceNameSuffix":"component-1","servicePort":"http"},"path":"/","pathType":"ImplementationSpecific"}` | backend defines the referenced service endpoint to which the traffic will be forwarded to |
@@ -44,7 +45,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | ingresses.ingress-1.rules[0].http.paths[0].backend.servicePort | string | `"http"` | servicePort describes the port where the service is listening at (can be either a string or a number) |
 | ingresses.ingress-1.rules[0].http.paths[0].path | string | `"/"` | path which ingress is listening |
 | ingresses.ingress-1.rules[0].http.paths[0].pathType | string | `"ImplementationSpecific"` | pathType Each path in an Ingress is required to have a corresponding path type. Comment out for using default ("ImplementationSpecific") |
-| ingresses.ingress-1.tls.existing.secret | string | `""` | name of an existing secret with tls.crt & tls.key content |
+| ingresses.ingress-1.rules[0].secretName | string | `""` | name of existing secrets with tls.crt & tls.key content |
 | ingresses.ingress-1.tls.provided.cert | string | `""` | If SSL is terminated on ingress and you have a generated (preferrably CERT-001) certificate/key Has to be base64 encoded and should be encrypted in the ejson vault Add Variable to your CI/CD Settings "SKIP_DECRYPT" with value "" that it doesnt decrypt the cert and fails. |
 | ingresses.ingress-1.tls.provided.key | string | `""` | The key must not have a passphrase |
 | ingresses.ingress-1.tls.self | object | `{"alternativeDnsNames":[],"commonName":"*.cluster.local","ipAddresses":[],"validityDuration":365}` | depending on the type you have further configuration options: |
@@ -52,7 +53,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | ingresses.ingress-1.tls.self.commonName | string | `"*.cluster.local"` | commonName of the certificate (mandatory) |
 | ingresses.ingress-1.tls.self.ipAddresses | list | `[]` | ipAddresses is an optional list of IP addresses to add in the Subject Alternative Names (SAN) section |
 | ingresses.ingress-1.tls.self.validityDuration | int | `365` | validityDuration defines how long the certificate is valid (in days) |
-| ingresses.ingress-1.tls.type | string | `"none"` | define your type of tls certificate, it can be one of: none: tls will be disabled existing: use an existing secret already present in the namespace. Requires secret name to be specified provided: use an officially generated certificate/key k8s: use the default k8s-ingress tls. no further configuration needed self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least |
+| ingresses.ingress-1.tls.type | string | `"none"` | define your type of tls certificate, it can be one of: none: tls will be disabled existing: use an existing secret already present in the namespace. Requires secret name to be specified in .rules.host.secret provided: use an officially generated certificate/key k8s: use the default k8s-ingress tls. no further configuration needed self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least |
 
 ## ServiceMonitor
 

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -24,7 +24,7 @@ Major Changes to functions are documented with the version affected. **Before up
 |networkpolicy template changes|9.0.0|add possibility to define more than one Port in networkpolicy|https://github.com/bedag/helm-charts/pull/70|
 |networkpolicy template changes|10.0.0|add possibility to create multiple networkpolicies|https://github.com/bedag/helm-charts/pull/77|
 |ingress template changes|11.0.0|add possibility to create multiple ingress objects|https://github.com/bedag/helm-charts/pull/134
-|ingress template changes|12.0.0|support defining multiple hosts and secrets for one ingress|
+|ingress template changes|12.0.0|support defining multiple hosts and secrets for one ingress|https://github.com/bedag/helm-charts/pull/138
 
 # Values by Component
 

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -53,7 +53,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | ingresses.ingress-1.tls.self.commonName | string | `"*.cluster.local"` | commonName of the certificate (mandatory) |
 | ingresses.ingress-1.tls.self.ipAddresses | list | `[]` | ipAddresses is an optional list of IP addresses to add in the Subject Alternative Names (SAN) section |
 | ingresses.ingress-1.tls.self.validityDuration | int | `365` | validityDuration defines how long the certificate is valid (in days) |
-| ingresses.ingress-1.tls.type | string | `"none"` | define your type of tls certificate, it can be one of: none: tls will be disabled existing: use an existing secret already present in the namespace. Requires secret name to be specified in .rules.host.secret provided: use an officially generated certificate/key k8s: use the default k8s-ingress tls. no further configuration needed self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least |
+| ingresses.ingress-1.tls.type | string | `"none"` | define your type of tls certificate, it can be one of: none: tls will be disabled existing: use an existing secret already present in the namespace. Requires secret name to be specified in .rules.host[].secretName provided: use an officially generated certificate/key k8s: use the default k8s-ingress tls. no further configuration needed self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least |
 
 ## ServiceMonitor
 

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -53,7 +53,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | ingresses.ingress-1.tls.self.commonName | string | `"*.cluster.local"` | commonName of the certificate (mandatory) |
 | ingresses.ingress-1.tls.self.ipAddresses | list | `[]` | ipAddresses is an optional list of IP addresses to add in the Subject Alternative Names (SAN) section |
 | ingresses.ingress-1.tls.self.validityDuration | int | `365` | validityDuration defines how long the certificate is valid (in days) |
-| ingresses.ingress-1.tls.type | string | `"none"` | define your type of tls certificate, it can be one of: none: tls will be disabled existing: use an existing secret already present in the namespace. Requires 'secretName' to be specified in .rules.host provided: use an officially generated certificate/key k8s: use the default k8s-ingress tls. no further configuration needed self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least |
+| ingresses.ingress-1.tls.type | string | `"none"` | define your type of tls certificate, it can be one of: none: tls will be disabled existing: use an existing secret already present in the namespace. Requires `secretName` to be specified in `.rules.host` provided: use an officially generated certificate/key k8s: use the default k8s-ingress tls. no further configuration needed self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least |
 
 ## ServiceMonitor
 

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -53,7 +53,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | ingresses.ingress-1.tls.self.commonName | string | `"*.cluster.local"` | commonName of the certificate (mandatory) |
 | ingresses.ingress-1.tls.self.ipAddresses | list | `[]` | ipAddresses is an optional list of IP addresses to add in the Subject Alternative Names (SAN) section |
 | ingresses.ingress-1.tls.self.validityDuration | int | `365` | validityDuration defines how long the certificate is valid (in days) |
-| ingresses.ingress-1.tls.type | string | `"none"` | define your type of tls certificate, it can be one of: none: tls will be disabled existing: use an existing secret already present in the namespace. Requires secret name to be specified in .rules.host[].secretName provided: use an officially generated certificate/key k8s: use the default k8s-ingress tls. no further configuration needed self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least |
+| ingresses.ingress-1.tls.type | string | `"none"` | define your type of tls certificate, it can be one of: none: tls will be disabled existing: use an existing secret already present in the namespace. Requires 'secretName' to be specified in .rules.host provided: use an officially generated certificate/key k8s: use the default k8s-ingress tls. no further configuration needed self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least |
 
 ## ServiceMonitor
 

--- a/charts/common/README.md.gotmpl
+++ b/charts/common/README.md.gotmpl
@@ -33,7 +33,7 @@ Major Changes to functions are documented with the version affected. **Before up
 |networkpolicy template changes|9.0.0|add possibility to define more than one Port in networkpolicy|https://github.com/bedag/helm-charts/pull/70|
 |networkpolicy template changes|10.0.0|add possibility to create multiple networkpolicies|https://github.com/bedag/helm-charts/pull/77|
 |ingress template changes|11.0.0|add possibility to create multiple ingress objects|https://github.com/bedag/helm-charts/pull/134
-|ingress template changes|12.0.0|support defining multiple hosts and secrets for one ingress|
+|ingress template changes|12.0.0|support defining multiple hosts and secrets for one ingress|https://github.com/bedag/helm-charts/pull/138
 {{/*
   Chart Values
 */}}

--- a/charts/common/README.md.gotmpl
+++ b/charts/common/README.md.gotmpl
@@ -33,6 +33,7 @@ Major Changes to functions are documented with the version affected. **Before up
 |networkpolicy template changes|9.0.0|add possibility to define more than one Port in networkpolicy|https://github.com/bedag/helm-charts/pull/70|
 |networkpolicy template changes|10.0.0|add possibility to create multiple networkpolicies|https://github.com/bedag/helm-charts/pull/77|
 |ingress template changes|11.0.0|add possibility to create multiple ingress objects|https://github.com/bedag/helm-charts/pull/134
+|ingress template changes|12.0.0|support defining multiple hosts and secrets for one ingress|
 {{/*
   Chart Values
 */}}

--- a/charts/common/templates/_ingress-ingress.yaml
+++ b/charts/common/templates/_ingress-ingress.yaml
@@ -57,7 +57,7 @@ spec:
     - hosts:
         - {{ .host }}
       {{- if or (eq $ingress.tls.type "self") (eq $ingress.tls.type "provided") }}
-      secretName:  {{ regexReplaceAll "\\W+" .host "-" }}
+      secretName: {{ regexReplaceAll "\\W+" .host "-" }}
       {{- else if eq $ingress.tls.type "existing" }}
       secretName: {{ .secretName }}
       {{- end }}

--- a/charts/common/templates/_ingress-ingress.yaml
+++ b/charts/common/templates/_ingress-ingress.yaml
@@ -53,15 +53,15 @@ spec:
   {{- if $ingress.tls }}
   {{- if and (ne $ingress.tls.type "none") (ne $ingress.tls.type "") }}
   tls:
+    {{- range $ingress.rules }}
     - hosts:
-      {{- range $ingress.rules }}
         - {{ .host }}
-      {{- end }}
       {{- if or (eq $ingress.tls.type "self") (eq $ingress.tls.type "provided") }}
-      secretName: {{ template "library.name" $root }}-{{$name}}-tls
+      secretName:  {{ regexReplaceAll "\\W+" .host "-" }}
       {{- else if eq $ingress.tls.type "existing" }}
-      secretName: {{ $ingress.tls.existing.secret }}
+      secretName: {{ .secretName }}
       {{- end }}
+    {{- end }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/common/templates/_ingress-secret.yaml
+++ b/charts/common/templates/_ingress-secret.yaml
@@ -11,11 +11,12 @@
 {{- $cert = buildCustomCert $ingress.tls.provided.cert $ingress.tls.provided.key }}
 {{- end }}
 {{ if or (eq $ingress.tls.type "self") (eq $ingress.tls.type "provided")}}
+{{- range $ingress.rules }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "library.name" $root }}-{{$name}}-tls
+  name: {{ regexReplaceAll "\\W+" .host "-" }}
   labels:
 {{ include "library.labels.standard" $root | indent 4 }}
     app.kubernetes.io/component: ingress-tls
@@ -23,6 +24,7 @@ type: Opaque
 data:
   tls.crt: {{ $cert.Cert | b64enc }}
   tls.key: {{ $cert.Key | b64enc }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -609,6 +609,9 @@
                         }
                       }
                     }
+                  },
+                  "secretName": {
+                    "type": "string"
                   }
                 }
               }
@@ -625,17 +628,6 @@
                 "type": {
                   "type": "string",
                   "default": "none"
-                },
-                "existing": {
-                  "type": "object",
-                  "required": [
-                    "secret"
-                  ],
-                  "properties": {
-                    "secret": {
-                      "type": "string"
-                    }
-                  }
                 },
                 "provided": {
                   "type": "object",

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -102,7 +102,7 @@ ingresses:
     tls:
       # -- define your type of tls certificate, it can be one of:
       # none: tls will be disabled
-      # existing: use an existing secret already present in the namespace. Requires secret name to be specified in .rules.host.secret
+      # existing: use an existing secret already present in the namespace. Requires secret name to be specified in .rules.host[].secretName
       # provided: use an officially generated certificate/key
       # k8s: use the default k8s-ingress tls. no further configuration needed
       # self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -102,7 +102,7 @@ ingresses:
     tls:
       # -- define your type of tls certificate, it can be one of:
       # none: tls will be disabled
-      # existing: use an existing secret already present in the namespace. Requires secret name to be specified in .rules.host[].secretName
+      # existing: use an existing secret already present in the namespace. Requires 'secretName' to be specified in .rules.host
       # provided: use an officially generated certificate/key
       # k8s: use the default k8s-ingress tls. no further configuration needed
       # self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -88,6 +88,8 @@ ingresses:
               path: "/"
               # -- pathType Each path in an Ingress is required to have a corresponding path type. Comment out for using default ("ImplementationSpecific")
               pathType: "ImplementationSpecific"
+        # -- name of existing secrets with tls.crt & tls.key content
+        secretName: ""
     # END ONLY FOR MULTI-SERVICE INGRESSES AND/OR SPECIFIC RULES
 
     # -- annotations is a dictionary for defining ingress controller specific annotations
@@ -100,7 +102,7 @@ ingresses:
     tls:
       # -- define your type of tls certificate, it can be one of:
       # none: tls will be disabled
-      # existing: use an existing secret already present in the namespace. Requires secret name to be specified
+      # existing: use an existing secret already present in the namespace. Requires secret name to be specified in .rules.host.secret
       # provided: use an officially generated certificate/key
       # k8s: use the default k8s-ingress tls. no further configuration needed
       # self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least
@@ -117,9 +119,6 @@ ingresses:
         #  - "foo.com"
         # -- validityDuration defines how long the certificate is valid (in days)
         validityDuration: 365
-      existing:
-        # -- name of an existing secret with tls.crt & tls.key content
-        secret: ""
       provided:
         # -- If SSL is terminated on ingress and you have a generated (preferrably CERT-001) certificate/key
         # Has to be base64 encoded and should be encrypted in the ejson vault

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -102,7 +102,7 @@ ingresses:
     tls:
       # -- define your type of tls certificate, it can be one of:
       # none: tls will be disabled
-      # existing: use an existing secret already present in the namespace. Requires 'secretName' to be specified in .rules.host
+      # existing: use an existing secret already present in the namespace. Requires `secretName` to be specified in `.rules.host`
       # provided: use an officially generated certificate/key
       # k8s: use the default k8s-ingress tls. no further configuration needed
       # self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least


### PR DESCRIPTION
**What this PR does**: This PR enhances the common chart with the ability to define multiple hosts (with and without existing secrets) for one single ingress.

**Notes for Reviewer**:


**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
