### PR TITLE
[vcluster]: switch kubeProxyReplacement to true instead of deprecated strict

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/addons/scripts/configure-vcluster.sh
+++ b/charts/vcluster/addons/scripts/configure-vcluster.sh
@@ -100,13 +100,13 @@ kubectl -n kube-system delete configmap/kube-proxy daemonset/kube-proxy 2>/dev/n
 {{- if $job.cilium.enabled }}
 if kubectl get ds cilium -n kube-system &> /dev/null; then
 	echo "Cilium already installed"
-else 
+else
   {{- if or (and ($job.cilium.on_install) ($.Release.IsInstall)) (not $job.cilium.on_install) }}
 # install cilium
 helm repo add cilium https://helm.cilium.io/
 helm upgrade --install cilium cilium/cilium {{ with $job.cilium.version }}--version {{ . }} {{ end }} \
     {{- if not ($kubernetes.kubeProxy.enabled) }}
-    --set kubeProxyReplacement=strict \
+    --set kubeProxyReplacement=true \
       {{- if (include "kubernetes.api.endpointIP" $) }}
     --set k8sServiceHost={{ include "kubernetes.api.endpointIP" $ }} \
     --set k8sServicePort={{ include "kubernetes.api.endpointPort" $ }} \


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:

https://docs.cilium.io/en/v1.14/operations/upgrade/#deprecated-options

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
