### PR TITLE
[vcluster]: respect bgpControlPlane in lifecycle.cilium, allow setting devices in lifecycle.cilium

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.6.2
+version: 0.7.0
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 
@@ -130,6 +130,8 @@ We use a lifecycle Job/Cronjob to manage certain configurations within the vclus
 |-----|------|---------|-------------|
 | lifecycle.argocd.namespace | string | `"argocd"` | Installation namespace of ArgoCD |
 | lifecycle.argocd.rbac | bool | `true` | Creates required rbac in argoCD namespace to create cluster secrets |
+| lifecycle.cilium.bgpControlPlane | object | `{"enabled":true}` | Enable BGP Control Plane feature |
+| lifecycle.cilium.devices | string | `""` | Specify which network interfaces can run the eBPF datapath |
 | lifecycle.cilium.enabled | bool | `true` | Install Cilium CNI |
 | lifecycle.cilium.on_install | bool | `true` | Install only on chart install (First install) |
 | lifecycle.cilium.version | string | `"1.9.18"` | Cilium version |

--- a/charts/vcluster/addons/scripts/configure-vcluster.sh
+++ b/charts/vcluster/addons/scripts/configure-vcluster.sh
@@ -107,6 +107,12 @@ helm repo add cilium https://helm.cilium.io/
 helm upgrade --install cilium cilium/cilium {{ with $job.cilium.version }}--version {{ . }} {{ end }} \
     {{- if not ($kubernetes.kubeProxy.enabled) }}
     --set kubeProxyReplacement=true \
+    {{- if $job.cilium.bgpControlPlane.enabled }}
+    --set bgpControlPlane.enabled=true \
+    {{- end }}
+    {{- if $job.cilium.devices }}
+    --set devices={{ $job.cilium.devices | quote }} \
+    {{- end }}
       {{- if (include "kubernetes.api.endpointIP" $) }}
     --set k8sServiceHost={{ include "kubernetes.api.endpointIP" $ }} \
     --set k8sServicePort={{ include "kubernetes.api.endpointPort" $ }} \

--- a/charts/vcluster/values.yaml
+++ b/charts/vcluster/values.yaml
@@ -180,6 +180,11 @@ lifecycle:
     version: 1.9.18
     # -- Install only on chart install (First install)
     on_install: true
+    # -- Enable BGP Control Plane feature
+    bgpControlPlane:
+      enabled: true
+    # -- Specify which network interfaces can run the eBPF datapath
+    devices: ""
 
   # Create Additional Kubeconfigs which you can directly use to access the cluster in your existing toolchain (See values.yaml)
   # @default -- See values.yaml


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:

- Fix: respect bgpControlPlane in lifecycle.cilium
- Feat: allow setting devices in lifecycle.cilium

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
