### PR TITLE
[vcluster]: llow installation of online manifests, disable autoscaler as default, remove unused values & fix references

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 
@@ -164,10 +164,8 @@ We use a lifecycle Job/Cronjob to manage certain configurations within the vclus
 | lifecycle.setup.schedule | string | `"0 0 1 */6 *"` | Cronjob Schedule |
 | lifecycle.setup.successfulJobsHistoryLimit | int | `3` | Cronjob successful jobs history limit |
 | lifecycle.setup.ttlSecondsAfterFinished | int | `120` | ttlSecondsAfterFinished for setup |
-| lifecycle.vcluster.cleanupScript | string | `nil` | Additional configuration script for the vcluster during cleanup (supports templating) |
-| lifecycle.vcluster.extraManifests | object | See values.yaml | These manifests will be applied inside the vcluster (supports templating) |
-| lifecycle.vcluster.extraManifestsOnInstall | object | See values.yaml | These manifests will be applied inside the vcluster, but only on $.Release.Install and wont be touched again (supports templating) |
-| lifecycle.vcluster.setupScript | string | `nil` | Additional configuration script for the vcluster during reconciler (supports templating) |
+| lifecycle.vcluster.extraOnlineManifests | list | `[]` | List of URLs which will be applied inside the vcluster (supports templating) |
+| lifecycle.vcluster.extraOnlineManifestsOnInstall | list | `[]` | List of URLs which will be applied inside the vcluster, but only on $.Release.Install and wont be touched again (supports templating) |
 
 ## Machine Values
 
@@ -844,7 +842,7 @@ Available Values for the [Autsocaler component](#autoscaler).
 ---
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| autoscaler.enabled | bool | `true` | Enable autsocaler component |
+| autoscaler.enabled | bool | `false` | Enable autsocaler component |
 | autoscaler.expanderPriorities | object | `{}` | The expanderPriorities is used if `extraArgs.expander` contains `priority` and expanderPriorities is also set with the priorities. If `args.expander` contains `priority`, then expanderPriorities is used to define cluster-autoscaler-priority-expander priorities. See: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md |
 | autoscaler.priorityConfigMapAnnotations | object | `{}` | Annotations to add to `cluster-autoscaler-priority-expander` ConfigMap. |
 
@@ -856,7 +854,7 @@ Available Values for the [Autsocaler component](#autoscaler).
 | autoscaler.affinity | object | `{}` | Affinity |
 | autoscaler.annotations | object | `{}` | Annotations for Workload |
 | autoscaler.args | object | `{"leader-elect":true,"logtostderr":true,"scale-down-enabled":true,"stderrthreshold":"info","v":4}` | Additional container arguments. Refer to https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca for the full list of cluster autoscaler parameters and their default values. Everything after the first _ will be ignored allowing the use of multi-string arguments. |
-| autoscaler.enabled | bool | `true` | Enable autsocaler component |
+| autoscaler.enabled | bool | `false` | Enable autsocaler component |
 | autoscaler.envs | object | `{"CAPI_GROUP":"cluster.k8s.io"}` | Extra environment variables (`key: value` style, allows templating) |
 | autoscaler.envsFrom | list | `[]` | Extra environment variables from |
 | autoscaler.expanderPriorities | object | `{}` | The expanderPriorities is used if `extraArgs.expander` contains `priority` and expanderPriorities is also set with the priorities. If `args.expander` contains `priority`, then expanderPriorities is used to define cluster-autoscaler-priority-expander priorities. See: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md |

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 
@@ -138,10 +138,8 @@ We use a lifecycle Job/Cronjob to manage certain configurations within the vclus
 | lifecycle.cleanup.annotations | object | `{"helm.sh/hook":"pre-delete","helm.sh/hook-delete-policy":"before-hook-creation"}` | Job Annotations |
 | lifecycle.cleanup.enabled | bool | `false` | Enable/Disable Cleanup |
 | lifecycle.cleanup.labels | object | `{}` | Job Labels |
-| lifecycle.current.cleanupScript | string | `nil` | Additional configuration script for the vcluster during cleanup (supports templating) |
 | lifecycle.current.extraManifests | object | See values.yaml | These manifests will be applied inside the cluster (supports templating) |
 | lifecycle.current.extraManifestsOnInstall | object | See values.yaml | These manifests will be applied inside the cluster, but only on $.Release.Install and wont be touched again (supports templating) |
-| lifecycle.current.setupScript | string | `nil` | Additional configuration script for the current cluster (supports templating) |
 | lifecycle.jobs.affinity | object | `{}` | Affinity |
 | lifecycle.jobs.extraEnv | list | `[]` | Additional Pod Environment variables |
 | lifecycle.jobs.extraVolumeMounts | list | `[]` | Additional Pod VolumeMounts |
@@ -395,7 +393,6 @@ Available Values for the [Operating System Manager](). The component consists of
 Available Values for the [Kubernetes component](#kubernetes).
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| kubernetes.component.removeManifestsOnDisable | bool | `true` | Remove all manifests on disable in the vcluster (**Attention**: When crds are deleted all crs will be deleted as well) |
 | kubernetes.controlPlane | object | `{"endpoint":null}` | ControlerPlaneEndpoint |
 | kubernetes.controlPlane.endpoint | string | `nil` | Endpoint for ControlPlane (eg `128.1314.1234.4242:6443`). If not set, the vcluster will try to find the endpoint automatically. |
 | kubernetes.enabled | bool | `true` | Enable Kubernetes Component |

--- a/charts/vcluster/addons/scripts/configure-current.sh
+++ b/charts/vcluster/addons/scripts/configure-current.sh
@@ -11,7 +11,7 @@ CA=$(base64 /pki/admin-client/ca.crt | tr -d '\n')
 C_CERT=$(base64 /pki/admin-client/tls.crt | tr -d '\n')
 C_KEY=$(base64 /pki/admin-client/tls.key | tr -d '\n')
 
-{{- $kubeconfigs := $.Values.lifecycle.kubeconfigs }}
+{{- $kubeconfigs := $lifecycle.kubeconfigs }}
 # Iterate over all kubeconfigs
 {{- range $kubeconfigs }}{{"\n"}}
   {{- $name := (include "pkg.utils.template" (dict "tpl" (required "kubeconfig.name is required" .name) "ctx" $)) -}}

--- a/charts/vcluster/addons/scripts/configure-vcluster.sh
+++ b/charts/vcluster/addons/scripts/configure-vcluster.sh
@@ -147,11 +147,11 @@ fi
 # Additional Manifests
 # ------------------------------------------------------------------------------
 {{- if $.Release.IsInstall }}
-  {{- with $lifecycle.vcluster.extraManifestsOnInstall }}
-kubectl apply{{- range $key, $value := . }} -f /manifests/{{ $key }} {{- end }}
+  {{- range $lifecycle.vcluster.extraOnlineManifests }}
+kubectl apply -f {{ . | quote }}
   {{- end }}
 {{- end }}
 
-{{- with $lifecycle.vcluster.extraManifests }}
-kubectl apply{{- range $key, $value := . }} -f /manifests/{{ $key }} {{- end }}
+{{- range $lifecycle.vcluster.extraOnlineManifestsOnInstall }}
+kubectl apply -f {{ . | quote }}
 {{- end }}

--- a/charts/vcluster/templates/components/kubernetes/kubeadm-config.yaml
+++ b/charts/vcluster/templates/components/kubernetes/kubeadm-config.yaml
@@ -15,8 +15,8 @@ data:
     apiVersion: kubeadm.k8s.io/v1beta3
     kind: ClusterConfiguration
     clusterName: {{ include "pkg.cluster.name" $ }}
-    {{- if $kubernetes.controlPlaneEndpoint }}
-    controlPlaneEndpoint: {{ $kubernetes.controlPlaneEndpoint }}
+    {{- if $kubernetes.controlPlane.endpoint }}
+    controlPlaneEndpoint: {{ $kubernetes.controlPlane.endpoint }}
     {{- else }}
     controlPlaneEndpoint: {{ include "kubernetes.api.service" $ }}:{{ $kubernetes.apiServer.service.port }}
     {{- end }}

--- a/charts/vcluster/templates/extra-manifests.yaml
+++ b/charts/vcluster/templates/extra-manifests.yaml
@@ -8,7 +8,7 @@ items:
   {{- if $.Release.IsInstall }}
     {{- with $.Values.lifecycle.current.extraManifestsOnInstall }}
       {{- range $file, $content := . }}
-    - {{- include "pkg.utils.template" (dict "tpl" $content "ctx" $) | nindent 4 }}
+  - {{- include "pkg.utils.template" (dict "tpl" $content "ctx" $) | nindent 4 }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/vcluster/values.yaml
+++ b/charts/vcluster/values.yaml
@@ -212,15 +212,6 @@ lifecycle:
 
   # Additional customization for interactions with the current cluster
   current:
-
-    # -- Additional configuration script for the current cluster (supports templating)
-    setupScript:
-    #  echo "I am a script which runs on the current cluster"
-
-    # -- Additional configuration script for the vcluster during cleanup (supports templating)
-    cleanupScript:
-    #  echo "I am a script which runs on the current cluster"
-
     # -- These manifests will be applied inside the cluster (supports templating)
     # @default -- See values.yaml
     extraManifests: {}
@@ -706,7 +697,7 @@ machine:
 # ----------------------------
 #  Operating System Manager
 # ----------------------------
-# Refernece:
+# Reference:
 osm:
   # -- Enable Operating System Manager Component
   enabled: false
@@ -1009,12 +1000,6 @@ osm:
 kubernetes:
   # -- Enable Kubernetes Component
   enabled: true
-
-  # Component Settings
-  component:
-
-    # -- Remove all manifests on disable in the vcluster (**Attention**: When crds are deleted all crs will be deleted as well)
-    removeManifestsOnDisable: true
 
   # -- Version for API Server, Scheduler, Controller Manager (Tag for all kubernetes components)
   version: "v1.25.0"
@@ -2165,7 +2150,7 @@ autoscaler:
     # balancing-ignore-label_1: first-label-to-ignore
     # balancing-ignore-label_2: second-label-to-ignore
 
-  # Image COnfiguration
+  # Image Configuration
   image:
     # -- Image registry
     registry: registry.k8s.io
@@ -2308,13 +2293,12 @@ autoscaler:
 # ----------------------------
 # Utilities
 # ----------------------------
-# -- kubeVersion Override Kubernetes version
-kubeVersion: ""
-
 utils:
   # -- Base Label used for labels
   base_label: "app.kubernetes.io"
-  # -- Timezone
-  timezone: "Europe/Zurich"
   # -- All controllers are installed on the current cluster without expecting a virtual API
   currentcluster: false
+  # -- kubeVersion Override Kubernetes version
+  kubeVersion: ""
+  # -- Timezone
+  timezone: "Europe/Zurich"

--- a/charts/vcluster/values.yaml
+++ b/charts/vcluster/values.yaml
@@ -234,34 +234,11 @@ lifecycle:
 
   # Additional customization for interactions with the vcluster cluster
   vcluster:
+    # -- List of URLs which will be applied inside the vcluster (supports templating)
+    extraOnlineManifests: []
 
-    # -- Additional configuration script for the vcluster during reconciler (supports templating)
-    setupScript:
-    #  echo "I am a script which runs on the vcluster"
-
-    # -- Additional configuration script for the vcluster during cleanup (supports templating)
-    cleanupScript:
-    #  echo "I am a script which runs on the vcluster"
-
-    # -- These manifests will be applied inside the vcluster (supports templating)
-    # @default -- See values.yaml
-    extraManifests: {}
-    # -- Filename of the manifest
-    # namespace.yaml:
-    #   apiVersion: v1
-    #   kind: Namespace
-    #   metadata:
-    #     name: example
-
-    # -- These manifests will be applied inside the vcluster, but only on $.Release.Install and wont be touched again (supports templating)
-    # @default -- See values.yaml
-    extraManifestsOnInstall: {}
-    # -- Filename of the manifest
-    # namespace.yaml:
-    #   apiVersion: v1
-    #   kind: Namespace
-    #   metadata:
-    #     name: example
+    # -- List of URLs which will be applied inside the vcluster, but only on $.Release.Install and wont be touched again (supports templating)
+    extraOnlineManifestsOnInstall: []
 
   # ArgoCD Lifecycle configuration
   argocd:
@@ -2102,7 +2079,7 @@ kubernetes:
 # ----------------------------
 autoscaler:
   # -- Enable autsocaler component
-  enabled: true
+  enabled: false
   ## Priorities Expander
   # -- The expanderPriorities is used if `extraArgs.expander` contains `priority` and expanderPriorities is also set with the priorities.
   # If `args.expander` contains `priority`, then expanderPriorities is used to define cluster-autoscaler-priority-expander priorities.


### PR DESCRIPTION
**What this PR does**:

- Disable autoscaler
- Fix reference of `.controlPlane.endpoint`
- Fix indentation in `charts/vcluster/templates/extra-manifests.yaml`
- Add `extraOnlineManifests` & `extraOnlineManifestsOnInstall` for vclusters

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
