### PR TITLE
[vcluster]: fix - use ServerSideApply for lifecycle tasks

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/addons/scripts/configure-vcluster.sh
+++ b/charts/vcluster/addons/scripts/configure-vcluster.sh
@@ -148,10 +148,10 @@ fi
 # ------------------------------------------------------------------------------
 {{- if $.Release.IsInstall }}
   {{- range $lifecycle.vcluster.extraOnlineManifests }}
-kubectl apply -f {{ . | quote }}
+kubectl apply --server-side -f {{ . | quote }}
   {{- end }}
 {{- end }}
 
 {{- range $lifecycle.vcluster.extraOnlineManifestsOnInstall }}
-kubectl apply -f {{ . | quote }}
+kubectl apply --server-side -f {{ . | quote }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:

Only using kubectl apply can result in an error if the changes are too big:
`The CustomResourceDefinition "thanosrulers.monitoring.coreos.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes`

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
