### PR TITLE
[vcluster]: fix - vcluster lifecycle tasks

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.8.1
+version: 0.8.2
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/addons/scripts/configure-vcluster.sh
+++ b/charts/vcluster/addons/scripts/configure-vcluster.sh
@@ -146,12 +146,12 @@ fi
 # ------------------------------------------------------------------------------
 # Additional Manifests
 # ------------------------------------------------------------------------------
-{{- if $.Release.IsInstall }}
-  {{- range $lifecycle.vcluster.extraOnlineManifests }}
-kubectl apply --server-side -f {{ . | quote }}
-  {{- end }}
+{{- range $lifecycle.vcluster.extraOnlineManifests }}
+kubectl apply --server-side -f {{ . | quote }} 2>/dev/null || true
 {{- end }}
 
-{{- range $lifecycle.vcluster.extraOnlineManifestsOnInstall }}
-kubectl apply --server-side -f {{ . | quote }}
+{{- if $.Release.IsInstall }}
+  {{- range $lifecycle.vcluster.extraOnlineManifestsOnInstall }}
+kubectl apply --server-side -f {{ . | quote }} 2>/dev/null || true
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:

extraOnlineManifests was only triggered onInstall.
extraOnlineManifestsOnInstall was triggered everytime.

This is fixed with this PR.

Additionally the job doesn't fail if the command is failing, since we're redirecting the STDERR to /dev/null and return always a zero exit code with || true.

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
