### PR TITLE
[common]: Enable mounting of existing secrets

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 12.2.0
+version: 12.3.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 12.2.0](https://img.shields.io/badge/Version-12.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 12.3.0](https://img.shields.io/badge/Version-12.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/templates/_pod.yaml
+++ b/charts/common/templates/_pod.yaml
@@ -59,18 +59,37 @@ volumes:
   - name: {{ template "library.name" $root }}-{{ .name }}
   {{- if eq .type "secret" }}
     secret:
+      {{- if .existing }}
+      secretName: {{ .name }}
+      {{- if .optional }}
+      optional: true
+      {{- end }}
+      {{- if .items }}
+      items:
+      {{- range .items }}
+        - key: {{ .key }}
+          path: {{ .path }}
+      {{- end }}
+      {{- end }}
+      {{- else }}
       secretName: {{ template "library.name" $root }}-{{ .name }}
+      {{- end }}
       {{- if .defaultMode }}
       defaultMode: {{ .defaultMode }}
       {{- end }}
   {{- else if eq .type "configMap" }}
     configMap:
-      {{- if .items }}
+      {{- if .existing }}
       name: {{ .name }}
+      {{- if .optional }}
+      optional: true
+      {{- end }}
+      {{- if .items }}
       items:
       {{- range .items }}
         - key: {{ .key }}
           path: {{ .path }}
+      {{- end }}
       {{- end }}
       {{- else }}
       name: {{ template "library.name" $root }}-{{ .name }}

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -1097,6 +1097,12 @@
                       "type": {
                         "type": "string"
                       },
+                      "existing": {
+                        "type": "boolean"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      },
                       "items": {
                         "type": "array",
                         "properties": {

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -465,10 +465,12 @@ components:
       # volumes is a list of volumes to be created as secret or configMap
       volumes: []
       #   -- name of the volume
-      # - name: generic-name or existing-cm-name
+      # - name: generic-name, existing-cm-name or existing-secret-name
       #   -- type can either be "secret", "configMap", "persistentVolumeClaim", "emptyDir", "external" or "csi"
       #    type: "secret"
-      #   START ONLY FOR CONFIGMAP
+      #   START ONLY FOR EXISTING CONFIGMAP AND EXISTING SECRET
+      #    existing: true # when mounting an existpöing ressource this has to be true
+      #    optional: true # false - prevents pod startup if the resource doesn't exist. See: https://kubernetes.io/docs/concepts/configuration/secret/#restriction-secret-must-exist
       #    items:
       #      - key: foo.txt
       #        path: opt/foo.txt

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -469,12 +469,12 @@ components:
       #   -- type can either be "secret", "configMap", "persistentVolumeClaim", "emptyDir", "external" or "csi"
       #    type: "secret"
       #   START ONLY FOR EXISTING CONFIGMAP AND EXISTING SECRET
-      #    existing: true # when mounting an existpöing ressource this has to be true
+      #    existing: true # when mounting an existing ressource this has to be true
       #    optional: true # false - prevents pod startup if the resource doesn't exist. See: https://kubernetes.io/docs/concepts/configuration/secret/#restriction-secret-must-exist
       #    items:
       #      - key: foo.txt
       #        path: opt/foo.txt
-      #   END ONLY FOR CONFIGMAP
+      #   END ONLY FOR EXISTING CONFIGMAP AND EXISTING SECRET
       #   START ONLY FOR SECRET or CONFIGMAP
       #   filePath is optional for specifying a filePath in the helm chart where the file is located.
       #    filePath: "files/xy.yml"


### PR DESCRIPTION
**What this PR does**:

Enable mounting of existing secrets and enable optional flag when mounting an existing ressources.
 
[https://kubernetes.io/docs/concepts/configuration/secret/#restriction-secret-must-exist](https://kubernetes.io/docs/concepts/configuration/secret/#restriction-secret-must-exist)

**Notes for Reviewer**:
mostly copied from: [https://github.com/bedag/helm-charts/pull/147](https://github.com/bedag/helm-charts/pull/147) 

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
