### PR TITLE
[common]: enable annotations for pvcs

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 12.2.0
+version: 12.3.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 12.3.0
+version: 12.4.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 12.2.0](https://img.shields.io/badge/Version-12.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 12.3.0](https://img.shields.io/badge/Version-12.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -2,7 +2,6 @@
 
 ![Version: 12.4.0](https://img.shields.io/badge/Version-12.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-
 Bedag's common Helm chart to use for creating other Helm charts
 
 ## Maintainers

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 12.3.0](https://img.shields.io/badge/Version-12.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 12.4.0](https://img.shields.io/badge/Version-12.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/templates/_pvcs.yaml
+++ b/charts/common/templates/_pvcs.yaml
@@ -7,6 +7,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "library.name" $root }}-{{ .name }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "library.labels.stable" $root | indent 4 }}
 spec:

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -780,6 +780,9 @@
               "name-of-pvc"
             ]
           },
+          "annotations": {
+            "type": "object"
+          },
           "size": {
             "type": "string",
             "default": "1Gi"

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -201,6 +201,8 @@ servicemonitor:
 pvcs:
     # -- specify the name of the pvc
 # - name: name-of-pvc
+    # -- add pvc specific annotations
+#   annotations: {}
     # size is optional with a default value of "1Gi"
 #   size: 10Gi
     # -- accessModes is an optional list with a default list with the following slice: "ReadWriteOnce"


### PR DESCRIPTION
**What this PR does**:

Allows setting annotations for PVCs. This is needed to set `helm.sh/resource-policy: keep` via the Helm Chart.
resolves: #135 

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
