### PR TITLE
[vcluster]: feat - etcd updates & etcd backup cleanup

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.8.2
+version: 0.9.0
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -603,6 +603,7 @@ Deploys [ETCD](https://etcd.io/).
 | kubernetes.etcd.cleanup.image.registry | string | `"docker.io"` | Image registry |
 | kubernetes.etcd.cleanup.image.repository | string | `"busybox"` | Image repository |
 | kubernetes.etcd.cleanup.image.tag | string | `"1.37.0"` | Image tag |
+| kubernetes.etcd.cleanup.imagePullSecrets | list | `[]` | Image pull Secrets |
 | kubernetes.etcd.cleanup.injectProxy | bool | `false` | Inject Proxy as Environment Variables |
 | kubernetes.etcd.cleanup.labels | object | `{}` | Labels for Workload |
 | kubernetes.etcd.cleanup.nodeSelector | object | `{}` | Node Selector |
@@ -693,6 +694,7 @@ Scheduled snapshots of ETCD via Cronjob.
 | kubernetes.etcd.backup.envs | object | `{}` | Extra environment variables (`key: value` style, allows templating) |
 | kubernetes.etcd.backup.envsFrom | list | `[]` | Extra environment variables from |
 | kubernetes.etcd.backup.failedJobsHistoryLimit | int | `3` | Failed Jobs History Limit for ETCD Backup |
+| kubernetes.etcd.backup.imagePullSecrets | list | `[]` | Image pull Secrets |
 | kubernetes.etcd.backup.injectProxy | bool | `false` | Inject Proxy as Environment Variables |
 | kubernetes.etcd.backup.labels | object | `{}` | Labels for Workload |
 | kubernetes.etcd.backup.nodeSelector | object | `{}` | Node Selector |

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 
@@ -425,6 +425,7 @@ Deploys [Kubernetes API Server](https://kubernetes.io/docs/reference/command-lin
 | kubernetes.apiServer.enabled | bool | `true` | Enable Kubernetes API-Server |
 | kubernetes.apiServer.envs | object | `{}` | Extra environment variables (`key: value` style, allows templating) |
 | kubernetes.apiServer.envsFrom | list | `[]` | Extra environment variables from |
+| kubernetes.apiServer.etcdEndpoints | string | `"pods"` | ETCD Endpoints on how the API-Server should communicate with the etcd cluster. Can be "pods" or "service" |
 | kubernetes.apiServer.image.digest | string | `""` | Image digest |
 | kubernetes.apiServer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | kubernetes.apiServer.image.registry | string | `"registry.k8s.io"` | Image registry |
@@ -591,6 +592,33 @@ Deploys [ETCD](https://etcd.io/).
 | kubernetes.etcd.args | object | `{"snapshot-count":10000}` | Extra arguments for ETCD |
 | kubernetes.etcd.certSANs.dnsNames | list | `[]` | Additonal DNS names for ETCD ceritifcate |
 | kubernetes.etcd.certSANs.ipAddresses | list | `[]` | Additonal IP adresses names for ETCD ceritifcate |
+| kubernetes.etcd.cleanup.affinity | object | `{}` | Affinity |
+| kubernetes.etcd.cleanup.annotations | object | `{}` | Annotations for Workload |
+| kubernetes.etcd.cleanup.enabled | bool | `false` | Enable ETCD Backup Cleanup |
+| kubernetes.etcd.cleanup.envs | object | `{}` | Extra environment variables (`key: value` style, allows templating) |
+| kubernetes.etcd.cleanup.envsFrom | list | `[]` | Extra environment variables from |
+| kubernetes.etcd.cleanup.failedJobsHistoryLimit | int | `3` | Failed Jobs History Limit for ETCD Backup Cleanup |
+| kubernetes.etcd.cleanup.image.digest | string | `""` | Image Digest |
+| kubernetes.etcd.cleanup.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| kubernetes.etcd.cleanup.image.registry | string | `"docker.io"` | Image registry |
+| kubernetes.etcd.cleanup.image.repository | string | `"busybox"` | Image repository |
+| kubernetes.etcd.cleanup.image.tag | string | `"1.37.0"` | Image tag |
+| kubernetes.etcd.cleanup.injectProxy | bool | `false` | Inject Proxy as Environment Variables |
+| kubernetes.etcd.cleanup.labels | object | `{}` | Labels for Workload |
+| kubernetes.etcd.cleanup.nodeSelector | object | `{}` | Node Selector |
+| kubernetes.etcd.cleanup.podAnnotations | object | `{}` | Pod Annotations |
+| kubernetes.etcd.cleanup.podLabels | object | `{}` | Pod Labels |
+| kubernetes.etcd.cleanup.podSecurityContext | object | `{"enabled":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod Security Context |
+| kubernetes.etcd.cleanup.priorityClassName | string | `""` | Pod PriorityClassName |
+| kubernetes.etcd.cleanup.resources | object | `{}` | Pod Requests and limits |
+| kubernetes.etcd.cleanup.restartPolicy | string | `"OnFailure"` | Restart Policy for ETCD Backup Cleanup |
+| kubernetes.etcd.cleanup.retentionDays | string | `"7"` | Number of days to keep backups |
+| kubernetes.etcd.cleanup.schedule | string | `"0 8 * * *"` | Schedule for ETCD Backup Cleanup |
+| kubernetes.etcd.cleanup.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"readOnlyRootFilesystem":true}` | Container Security Context |
+| kubernetes.etcd.cleanup.successfulJobsHistoryLimit | int | `3` | Successful Jobs History Limit for ETCD Backup Cleanup |
+| kubernetes.etcd.cleanup.tolerations | list | `[]` | Tolerations |
+| kubernetes.etcd.cleanup.topologySpreadConstraints | list | `[]` | TopologySpreadConstraints for all workloads |
+| kubernetes.etcd.cleanup.ttlSecondsAfterFinished | int | `120` | ttlSecondsAfterFinished for ETCD Backup Cleanup |
 | kubernetes.etcd.enabled | bool | `true` | Enable ETCD |
 | kubernetes.etcd.envs | object | `{}` | Extra environment variables (`key: value` style, allows templating) |
 | kubernetes.etcd.envsFrom | list | `[]` | Extra environment variables from |
@@ -598,10 +626,15 @@ Deploys [ETCD](https://etcd.io/).
 | kubernetes.etcd.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | kubernetes.etcd.image.registry | string | `"registry.k8s.io"` | Image registry |
 | kubernetes.etcd.image.repository | string | `"etcd"` | Image repository |
-| kubernetes.etcd.image.tag | string | `"3.5.7-0"` | Image tag |
+| kubernetes.etcd.image.tag | string | `"3.5.21-0"` | Image tag |
 | kubernetes.etcd.imagePullSecrets | list | `[]` | Image pull Secrets |
 | kubernetes.etcd.injectProxy | bool | `false` | Inject Proxy as Environment Variables |
 | kubernetes.etcd.labels | object | `{}` | Labels for Workload |
+| kubernetes.etcd.livenessProbe.failureThreshold | int | `8` | Set failure threshold for livenessProbe |
+| kubernetes.etcd.livenessProbe.initialDelaySeconds | int | `15` | Set initial delay seconds for livenessProbe |
+| kubernetes.etcd.livenessProbe.path | string | `"/livez"` | Set path for livenessProbe |
+| kubernetes.etcd.livenessProbe.scheme | string | `"HTTP"` | Set scheme for livenessProbe |
+| kubernetes.etcd.livenessProbe.timeoutSeconds | int | `15` | Set timeout seconds for livenessProbe |
 | kubernetes.etcd.metrics.service.annotations | object | `{}` | Service Annotations |
 | kubernetes.etcd.metrics.service.labels | object | `{}` | Service Labels |
 | kubernetes.etcd.metrics.serviceMonitor.annotations | object | `{}` | Assign additional Annotations |
@@ -632,6 +665,11 @@ Deploys [ETCD](https://etcd.io/).
 | kubernetes.etcd.ports.metrics | int | `2381` | ETCD Metrics Port |
 | kubernetes.etcd.ports.peer | int | `2380` | ETCD Peer Port |
 | kubernetes.etcd.priorityClassName | string | `""` | Pod PriorityClassName |
+| kubernetes.etcd.readinessProbe.failureThreshold | int | `3` | Set failure threshold for readinessProbe |
+| kubernetes.etcd.readinessProbe.initialDelaySeconds | int | `15` | Set initial delay seconds for readinessProbe |
+| kubernetes.etcd.readinessProbe.path | string | `"/readyz"` | Set path for readinessProbe |
+| kubernetes.etcd.readinessProbe.scheme | string | `"HTTP"` | Set scheme for readinessProbe |
+| kubernetes.etcd.readinessProbe.timeoutSeconds | int | `5` | Set timeout seconds for readinessProbe |
 | kubernetes.etcd.replicaCount | int | `3` | Replicas for ETCD Pods |
 | kubernetes.etcd.resources | object | `{"requests":{"cpu":"100m","memory":"128Mi"}}` | Pod Requests and limits |
 | kubernetes.etcd.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"readOnlyRootFilesystem":true}` | Container Security Context |

--- a/charts/vcluster/templates/components/kubernetes/_templates.tpl
+++ b/charts/vcluster/templates/components/kubernetes/_templates.tpl
@@ -84,12 +84,16 @@ Generate etcd servers list.
 {{- define "kubernetes.etcdEndpoints" -}}
   {{- $kubernetes := $.Values.kubernetes -}}
   {{- $fullName := include "kubernetes.fullname" . -}}
-  {{- range $etcdcount, $e := until (int $kubernetes.etcd.replicaCount) -}}
-    {{- printf "https://" -}}
-    {{- printf "%s-etcd-%d." $fullName $etcdcount -}}
-    {{- printf "%s-etcd.%s:%d" $fullName $.Release.Namespace (int $kubernetes.etcd.ports.client) -}}
-    {{- if lt $etcdcount (sub (int $kubernetes.etcd.replicaCount) 1 ) -}}
-      {{- printf "," -}}
+  {{- if eq $kubernetes.apiServer.etcdEndpoints "service" -}}
+    {{- printf "https://%s-etcd.%s:%d" $fullName $.Release.Namespace (int $kubernetes.etcd.ports.client) -}}
+  {{- else -}}
+    {{- range $etcdcount, $e := until (int $kubernetes.etcd.replicaCount) -}}
+      {{- printf "https://" -}}
+      {{- printf "%s-etcd-%d." $fullName $etcdcount -}}
+      {{- printf "%s-etcd.%s:%d" $fullName $.Release.Namespace (int $kubernetes.etcd.ports.client) -}}
+      {{- if lt $etcdcount (sub (int $kubernetes.etcd.replicaCount) 1 ) -}}
+        {{- printf "," -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/vcluster/templates/components/kubernetes/etcd/cleanup-job.yaml
+++ b/charts/vcluster/templates/components/kubernetes/etcd/cleanup-job.yaml
@@ -104,8 +104,8 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
             env:
-              - name: ETCD_SNAPSHOT_RETENTION_DAYS
-                value: {{ $kubernetes.etcd.cleanup.retentionDays | quote }}
+            - name: ETCD_SNAPSHOT_RETENTION_DAYS
+              value: {{ $kubernetes.etcd.cleanup.retentionDays | quote }}
             {{- if $kubernetes.etcd.cleanup.injectProxy }}
               {{- include "pkg.common.env.w-proxy" $ | nindent 12 }}
             {{- else }}

--- a/charts/vcluster/templates/components/kubernetes/etcd/cleanup-job.yaml
+++ b/charts/vcluster/templates/components/kubernetes/etcd/cleanup-job.yaml
@@ -1,0 +1,141 @@
+{{- if (include "kubernetes.enabled" $) -}}
+  {{- $kubernetes := $.Values.kubernetes -}}
+  {{- if and $kubernetes.etcd.enabled $kubernetes.etcd.cleanup.enabled -}}
+    {{- $fullName := include "kubernetes.fullname" . -}}
+    {{- $component_name := "etcd" -}}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $fullName }}-etcd-cleanup
+  labels: {{- include "kubernetes.labels" $ | nindent 4 }}
+    {{ include "pkg.common.labels.component" $ }}: {{ $component_name }}
+    {{- with (include "pkg.components.labels" (dict "labels" $kubernetes.etcd.cleanup.labels "ctx" $)) }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with (include "pkg.components.annotations" (dict "annotations" $kubernetes.etcd.cleanup.annotations "ctx" $)) }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  schedule: "{{ $kubernetes.etcd.cleanup.schedule }}"
+  successfulJobsHistoryLimit: {{ $kubernetes.etcd.cleanup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $kubernetes.etcd.cleanup.failedJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{ include "pkg.common.labels.component" $ }}: {{ $component_name }}
+        {{- with (include "pkg.components.labels" (dict "labels" $kubernetes.etcd.cleanup.labels "ctx" $)) }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with (include "pkg.components.annotations" (dict "annotations" $kubernetes.etcd.cleanup.annotations "ctx" $)) }}
+      annotations:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with $kubernetes.etcd.cleanup.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ . }}
+      {{- end }}
+      template:
+        metadata:
+          labels: {{- include "kubernetes.labels" $ | nindent 12 }}
+            {{- include "pkg.components.pod_labels" (dict "labels" $kubernetes.etcd.cleanup.podLabels "ctx" $) | nindent 12 }}
+            {{ include "pkg.common.labels.component" $ }}: {{ $component_name }}
+          annotations:
+            {{- include "pkg.components.pod_annotations" (dict "annotations" $kubernetes.etcd.cleanup.podAnnotations "ctx" $) | nindent 12 }}
+        spec:
+          {{- with (include "pkg.components.nodeselector" (dict "nodeSelector" $kubernetes.etcd.cleanup.nodeSelector "ctx" $)) }}
+          nodeSelector: {{- . | nindent 12 }}
+          {{- end }}
+          {{- with (include "pkg.components.tolerations" (dict "tolerations" $kubernetes.etcd.cleanup.tolerations "ctx" $)) }}
+          tolerations:  {{- . | nindent 12 }}
+          {{- end }}
+          {{- with (include "pkg.components.priorityClass" (dict "pc" $kubernetes.etcd.cleanup.priorityClassName "ctx" $)) }}
+          priorityClassName: {{ . }}
+          {{- end }}
+          {{- with (include "pkg.components.topologySpreadConstraints" (dict "tsc" $kubernetes.etcd.cleanup.topologySpreadConstraints "ctx" $)) }}
+          topologySpreadConstraints: {{ . | nindent 12 }}
+          {{- end }}
+          affinity:
+          {{- with (include "pkg.components.affinity" (dict "affinity" $kubernetes.etcd.cleanup.affinity "ctx" $)) }}
+            {{- . | nindent 10 }}
+          {{- end }}
+          {{- if eq $kubernetes.etcd.cleanup.podAntiAffinity "hard" }}
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: "{{ $kubernetes.etcd.cleanup.podAntiAffinityTopologyKey }}"
+                  labelSelector:
+                    matchLabels:
+                      app: {{ $fullName }}-etcd
+          {{- else if eq $kubernetes.etcd.cleanup.podAntiAffinity "soft" }}
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  podAffinityTerm:
+                    topologyKey: "{{ $kubernetes.etcd.cleanup.podAntiAffinityTopologyKey }}"
+                    labelSelector:
+                      matchLabels:
+                        app: {{ $fullName }}-etcd
+          {{- end }}
+          imagePullSecrets: {{- include "pkg.images.registry.pullsecrets" $ | nindent 10 }}
+            {{- with $kubernetes.etcd.cleanup.imagePullSecrets }}
+              {{- toYaml . | nindent 10 }}
+            {{- end }}
+          automountServiceAccountToken: false
+          restartPolicy: {{ $kubernetes.etcd.cleanup.restartPolicy }}
+          containers:
+          - command:
+            - /bin/sh
+            - -xc
+            - |
+              SNAPSHOT_DIR="/snapshots"
+              echo "Starting snapshot cleanup..."
+              echo "Retention: $ETCD_SNAPSHOT_RETENTION_DAYS day(s)"
+              echo "Snapshot directory: $SNAPSHOT_DIR"
+              if [ -d "$SNAPSHOT_DIR" ]; then
+                find "$SNAPSHOT_DIR" -name '*.db' -type f -mtime +"$ETCD_SNAPSHOT_RETENTION_DAYS" -print -delete
+              else
+                echo "Snapshot directory $SNAPSHOT_DIR not found!"
+                exit 1
+              fi
+            {{- with $kubernetes.etcd.cleanup.envsFrom }}
+            envFrom:
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            env:
+              - name: ETCD_SNAPSHOT_RETENTION_DAYS
+                value: {{ $kubernetes.etcd.cleanup.retentionDays | quote }}
+            {{- if $kubernetes.etcd.cleanup.injectProxy }}
+              {{- include "pkg.common.env.w-proxy" $ | nindent 12 }}
+            {{- else }}
+              {{- include "pkg.common.env" $ | nindent 12 }}
+            {{- end }}
+            {{- with $kubernetes.etcd.cleanup.envs }}
+              {{- include "pkg.utils.envs" (dict "envs" . "ctx" $) | nindent 12 }}
+            {{- end }}
+            {{- with $kubernetes.etcd.cleanup.image }}
+            image: {{ include "pkg.images.registry.convert" (dict "image" . "ctx" $) }}
+            imagePullPolicy: {{ include "pkg.images.registry.pullpolicy" (dict "policy" .pullPolicy "ctx" $) }}
+            {{- end }}
+            name: etcd-cleanup
+            {{- with (include "pkg.components.securityContext" (dict "sc" $kubernetes.etcd.cleanup.securityContext "ctx" $)) }}
+            securityContext: {{ . | nindent 14 }}
+            {{- end }}
+            resources:
+              {{- toYaml $kubernetes.etcd.cleanup.resources | nindent 14 }}
+            volumeMounts:
+            - mountPath: /snapshots
+              name: snapshots
+              {{- with $kubernetes.etcd.backup.persistence.subPath }}
+              subPath: {{ . }}
+              {{- end }}
+          {{- with (include "pkg.components.podSecurityContext" (dict "psc" $kubernetes.etcd.cleanup.podSecurityContext "ctx" $)) }}
+          securityContext: {{ . | nindent 12 }}
+          {{- end }}
+          volumes:
+          - name: snapshots
+            persistentVolumeClaim:
+              claimName: {{ $kubernetes.etcd.backup.persistence.existingClaim | default (printf "%s-etcd-backup" $fullName) }}
+  {{- end -}}
+{{- end -}}

--- a/charts/vcluster/templates/components/kubernetes/etcd/statefulset.yaml
+++ b/charts/vcluster/templates/components/kubernetes/etcd/statefulset.yaml
@@ -143,13 +143,21 @@ spec:
         - containerPort: {{ $kubernetes.etcd.ports.metrics }}
           name: http-metrics
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: {{ $kubernetes.etcd.livenessProbe.failureThreshold }}
           httpGet:
-            path: /health
+            path: {{ $kubernetes.etcd.livenessProbe.path | quote }}
             port: {{ $kubernetes.etcd.ports.metrics }}
-            scheme: HTTP
-          initialDelaySeconds: 15
-          timeoutSeconds: 15
+            scheme: {{ $kubernetes.etcd.livenessProbe.scheme | quote }}
+          initialDelaySeconds: {{ $kubernetes.etcd.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ $kubernetes.etcd.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          failureThreshold: {{ $kubernetes.etcd.readinessProbe.failureThreshold }}
+          httpGet:
+            path: {{ $kubernetes.etcd.readinessProbe.path | quote }}
+            port: {{ $kubernetes.etcd.ports.metrics }}
+            scheme: {{ $kubernetes.etcd.readinessProbe.scheme | quote }}
+          initialDelaySeconds: {{ $kubernetes.etcd.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ $kubernetes.etcd.readinessProbe.timeoutSeconds }}
         name: etcd
         resources:
           {{- toYaml $kubernetes.etcd.resources | nindent 10 }}

--- a/charts/vcluster/templates/pkg/_common.tpl
+++ b/charts/vcluster/templates/pkg/_common.tpl
@@ -143,11 +143,11 @@ Common Selector Labels
 {{- define "pkg.common.proxy.env" -}}
   {{- if (include "pkg.common.proxy.enabled" $) -}}
     {{- with (include "pkg.common.proxy.host" $) }}
-- name: "HTTP_RROXY"
+- name: "HTTP_PROXY"
   value: {{ . | quote }}
 - name: "http_proxy"
   value: {{ . | quote }}
-- name: "HTTPS_RROXY"
+- name: "HTTPS_PROXY"
   value: {{ . | quote }}
 - name: "https_proxy"
   value: {{ . | quote }}

--- a/charts/vcluster/templates/pkg/_images.tpl
+++ b/charts/vcluster/templates/pkg/_images.tpl
@@ -59,8 +59,8 @@ kube-system
   {{- if (include "pkg.images.registry.auth" $) }}
 - name: {{ template "pkg.images.registry.secretname" $ }}
   {{- end }}
-  {{- if $components.workloads.image.pullsecrets }}
-     {{- toYaml $components.workloads.image.pullsecrets | nindent 0 }}
+  {{- if $components.workloads.image.pullSecrets }}
+    {{- toYaml $components.workloads.image.pullSecrets | nindent 0 }}
   {{- end }}
 {{- end -}}
 

--- a/charts/vcluster/values.yaml
+++ b/charts/vcluster/values.yaml
@@ -1018,7 +1018,7 @@ kubernetes:
       # -- Image repository
       repository: etcd
       # -- Image tag
-      tag: 3.5.7-0
+      tag: 3.5.21-0
       # -- Image Digest
       digest: ""
       # -- Image pull policy
@@ -1086,7 +1086,30 @@ kubernetes:
     minReadySeconds: 10
     # -- Update Strategy
     updateStrategy: {}
-
+    # livenessProbe
+    livenessProbe:
+      # -- Set failure threshold for livenessProbe
+      failureThreshold: 8
+      # -- Set initial delay seconds for livenessProbe
+      initialDelaySeconds: 15
+      # -- Set timeout seconds for livenessProbe
+      timeoutSeconds: 15
+      # -- Set path for livenessProbe
+      path: "/livez"
+      # -- Set scheme for livenessProbe
+      scheme: "HTTP"
+    # readinessProbe
+    readinessProbe:
+      # -- Set failure threshold for readinessProbe
+      failureThreshold: 3
+      # -- Set initial delay seconds for readinessProbe
+      initialDelaySeconds: 15
+      # -- Set timeout seconds for readinessProbe
+      timeoutSeconds: 5
+      # -- Set path for readinessProbe
+      path: "/readyz"
+      # -- Set scheme for readinessProbe
+      scheme: "HTTP"
     # Persistence
     persistence:
       # -- Enable Persistence for ETCD
@@ -1245,10 +1268,84 @@ kubernetes:
         finalizers:
           - kubernetes.io/pvc-protection
 
+    # ETCD Backup Cleanup
+    cleanup:
+      # -- Enable ETCD Backup Cleanup
+      enabled: false
+      # -- Number of days to keep backups
+      retentionDays: "7"
+      # -- Schedule for ETCD Backup Cleanup
+      schedule: "0 8 * * *"
+      # -- Successful Jobs History Limit for ETCD Backup Cleanup
+      successfulJobsHistoryLimit: 3
+      # -- Failed Jobs History Limit for ETCD Backup Cleanup
+      failedJobsHistoryLimit: 3
+      # -- ttlSecondsAfterFinished for ETCD Backup Cleanup
+      ttlSecondsAfterFinished: 120
+      # -- Restart Policy for ETCD Backup Cleanup
+      restartPolicy: OnFailure
+      # Image
+      image:
+        # -- Image registry
+        registry: docker.io
+        # -- Image repository
+        repository: busybox
+        # -- Image tag
+        tag: 1.37.0
+        # -- Image Digest
+        digest: ""
+        # -- Image pull policy
+        pullPolicy: IfNotPresent
+      # -- Pod Requests and limits
+      resources: {}
+      # -- Labels for Workload
+      labels: {}
+      # -- Annotations for Workload
+      annotations: {}
+      # -- Pod Labels
+      podLabels: {}
+      # -- Pod Annotations
+      podAnnotations: {}
+      # -- Extra environment variables (`key: value` style, allows templating)
+      envs: {}
+      # -- Extra environment variables from
+      envsFrom: []
+      # -- Inject Proxy as Environment Variables
+      injectProxy: false
+      # -- Pod Security Context
+      podSecurityContext:
+        enabled: true
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      # -- Container Security Context
+      securityContext:
+        enabled: true
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+          - ALL
+      # -- Node Selector
+      nodeSelector: {}
+      # -- Tolerations
+      tolerations: []
+      podAntiAffinity: soft
+      podAntiAffinityTopologyKey: kubernetes.io/hostname
+      # -- Affinity
+      affinity: {}
+      # -- Pod PriorityClassName
+      priorityClassName: ""
+      # -- TopologySpreadConstraints for all workloads
+      topologySpreadConstraints: []
+
   ## Kubernetes API-Server
   apiServer:
     # -- Enable Kubernetes API-Server
     enabled: true
+
+    # -- ETCD Endpoints on how the API-Server should communicate with the etcd cluster. Can be "pods" or "service"
+    etcdEndpoints: "pods"
 
     certSANs:
       # -- Additonal API-Server dns names for ETCD ceritifcate

--- a/charts/vcluster/values.yaml
+++ b/charts/vcluster/values.yaml
@@ -1198,6 +1198,8 @@ kubernetes:
       ttlSecondsAfterFinished: 120
       # -- Restart Policy for ETCD Backup
       restartPolicy: OnFailure
+      # -- Image pull Secrets
+      imagePullSecrets: []
       # -- Extra arguments for ETCD Backup
       args: {}
       # -- Pod Requests and limits
@@ -1296,6 +1298,8 @@ kubernetes:
         digest: ""
         # -- Image pull policy
         pullPolicy: IfNotPresent
+      # -- Image pull Secrets
+      imagePullSecrets: []
       # -- Pod Requests and limits
       resources: {}
       # -- Labels for Workload


### PR DESCRIPTION
**What this PR does**:

- Update etcd image from `3.5.7-0` to `3.5.21-0`
- Update etcd livenessProbe to `/livez` endpoint
- Make etcd livenessProbe options configurable
- Add etcd readinessProbe (`/readyz`)
- Make etcd endpoints available through service dns instead of list of pod dns
- Add cleanup CronJob for etcd backups
- Fix typo in proxy envs injection
- Fix typos & spelling in `values.yaml` & `README.md`
- Fix bugs in imagePullSecrets

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
