### PR TITLE
[vcluster]: fix - always expose all etcd endpoitns for etcdctl

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/templates/components/kubernetes/_templates.tpl
+++ b/charts/vcluster/templates/components/kubernetes/_templates.tpl
@@ -98,6 +98,19 @@ Generate etcd servers list.
   {{- end -}}
 {{- end -}}
 
+{{- define "kubernetes.etcdCtlEndpoints" -}}
+  {{- $kubernetes := $.Values.kubernetes -}}
+  {{- $fullName := include "kubernetes.fullname" . -}}
+  {{- range $etcdcount, $e := until (int $kubernetes.etcd.replicaCount) -}}
+    {{- printf "https://" -}}
+    {{- printf "%s-etcd-%d." $fullName $etcdcount -}}
+    {{- printf "%s-etcd.%s:%d" $fullName $.Release.Namespace (int $kubernetes.etcd.ports.client) -}}
+    {{- if lt $etcdcount (sub (int $kubernetes.etcd.replicaCount) 1 ) -}}
+      {{- printf "," -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "kubernetes.etcdInitialCluster" -}}
   {{- $kubernetes := $.Values.kubernetes -}}
   {{- $fullName := include "kubernetes.fullname" . -}}

--- a/charts/vcluster/templates/components/kubernetes/etcd/statefulset.yaml
+++ b/charts/vcluster/templates/components/kubernetes/etcd/statefulset.yaml
@@ -124,7 +124,7 @@ spec:
         - name: ETCDCTL_KEY
           value: /pki/etcd/peer/tls.key
         - name: ETCDCTL_ENDPOINTS
-          value: {{ template "kubernetes.etcdEndpoints" . }}
+          value: {{ template "kubernetes.etcdCtlEndpoints" . }}
         {{- with $kubernetes.etcd.envs }}
           {{- include "pkg.utils.envs" (dict "envs" . "ctx" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
**What this PR does**:

- Add all etcd members to ETCDCTL_ENDPOINTS, so requests with etcdctl returns information of each endpoint instead of only 1 member over the service.

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
