### PR TITLE
[vcluster]: update etcd to latest

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.9.1
+version: 0.10.0
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 
@@ -589,7 +589,7 @@ Deploys [ETCD](https://etcd.io/).
 |-----|------|---------|-------------|
 | kubernetes.etcd.affinity | object | `{}` | Affinity |
 | kubernetes.etcd.annotations | object | `{}` | Annotations for Workload |
-| kubernetes.etcd.args | object | `{"snapshot-count":10000}` | Extra arguments for ETCD |
+| kubernetes.etcd.args | object | `{}` | Extra arguments for ETCD |
 | kubernetes.etcd.certSANs.dnsNames | list | `[]` | Additional DNS names for ETCD certificate |
 | kubernetes.etcd.certSANs.ipAddresses | list | `[]` | Additional IP addresses names for ETCD certificate |
 | kubernetes.etcd.cleanup.affinity | object | `{}` | Affinity |
@@ -627,7 +627,7 @@ Deploys [ETCD](https://etcd.io/).
 | kubernetes.etcd.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | kubernetes.etcd.image.registry | string | `"registry.k8s.io"` | Image registry |
 | kubernetes.etcd.image.repository | string | `"etcd"` | Image repository |
-| kubernetes.etcd.image.tag | string | `"3.5.21-0"` | Image tag |
+| kubernetes.etcd.image.tag | string | `"3.6.4-0"` | Image tag |
 | kubernetes.etcd.imagePullSecrets | list | `[]` | Image pull Secrets |
 | kubernetes.etcd.injectProxy | bool | `false` | Inject Proxy as Environment Variables |
 | kubernetes.etcd.labels | object | `{}` | Labels for Workload |

--- a/charts/vcluster/values.yaml
+++ b/charts/vcluster/values.yaml
@@ -1008,8 +1008,7 @@ kubernetes:
       ipAddresses: []
 
     # -- Extra arguments for ETCD
-    args:
-      snapshot-count: 10000
+    args: {}
 
     # https://console.cloud.google.com/gcr/images/etcd-development/GLOBAL/etcd?pli=1
     image:
@@ -1018,7 +1017,7 @@ kubernetes:
       # -- Image repository
       repository: etcd
       # -- Image tag
-      tag: 3.5.21-0
+      tag: 3.6.4-0
       # -- Image Digest
       digest: ""
       # -- Image pull policy


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:

For using kubernetes v1.33.x we update etcd to v3.6.x.
Announcement: https://kubernetes.io/blog/2025/05/15/announcing-etcd-3.6/

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
