### PR TITLE
[vcluster]: add secondary pull registries, add mirror registries, remove obsolete cli flags, enable chart-testing

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.10.0
+version: 0.11.0
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 
@@ -108,9 +108,12 @@ Global Values
 | global.components.workloads.topologySpreadConstraints | list | `[]` | TopologySpreadConstraints for all workloads (Overwrites all workloads topologySpreadConstraints) |
 | global.proxy.host | string | `""` | Proxy Host |
 | global.proxy.no_proxy | string | `"10.0.0.0/8"` | No Proxy Hosts |
-| global.registry.creds.password | string | `""` | Registry Password |
-| global.registry.creds.username | string | `""` | Registry Username |
-| global.registry.endpoint | string | `""` | Registry Endpoint |
+| global.registries.mirrors | object | `{}` | Registry Mirrors (used for containerd config) |
+| global.registries.primary | object | `{"creds":{"password":"","username":""},"endpoint":""}` | Default Registry (used for kubeadm, node-registry-mirrors etc.) |
+| global.registries.primary.creds.password | string | `""` | Registry Password |
+| global.registries.primary.creds.username | string | `""` | Registry Username |
+| global.registries.primary.endpoint | string | `""` | Registry Endpoint |
+| global.registries.secondaries | object | `{}` | Additional Registries (used in regcred secret) |
 | global.storageClassName | string | `""` | StorageClassName for all persistent volumes |
 
 ## Utilities Values
@@ -185,7 +188,6 @@ Available Values for the [Machine Controller Component](#machine-controller). Th
 | machine.component.removeManifestsOnDisable | bool | `true` | Remove all manifests on disable in the vcluster (**Attention**: When crds are deleted all crs will be deleted as well) |
 | machine.enabled | bool | `true` | Enable Machine-Controller Component |
 | machine.imagePullSecrets | list | `[]` | Image pull Secrets |
-| machine.kubelet.featureGates | list | `[]` | FeatureGates for kubelet |
 | machine.labels | object | `{}` | Labels for Workload |
 | machine.metrics.service.annotations | object | `{}` | Service Annotations |
 | machine.metrics.service.labels | object | `{}` | Service Labels |
@@ -201,18 +203,12 @@ Available Values for the [Machine Controller Component](#machine-controller). Th
 | machine.metrics.serviceMonitor.namespace | string | `""` | Install the ServiceMonitor into a different Namespace, as the monitoring stack one (default: the release one) |
 | machine.metrics.serviceMonitor.targetLabels | list | `[]` | Set targetLabels for the serviceMonitor |
 | machine.nodeSelector | object | `{}` | Node Selector |
-| machine.pause.image.digest | string | `""` | Image Digest |
-| machine.pause.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| machine.pause.image.registry | string | `""` | Image registry |
-| machine.pause.image.repository | string | `"pause"` | Image repository |
-| machine.pause.image.tag | string | `"3.5"` | Image tag |
 | machine.podAnnotations | object | `{}` | Pod Annotations |
 | machine.podDisruptionBudget | object | `{}` | Configure PodDisruptionBudget |
 | machine.podLabels | object | `{}` | Pod Labels |
 | machine.podSecurityContext | object | `{"enabled":true,"runAsNonRoot":false,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod Security Context |
 | machine.priorityClassName | string | `""` | Pod PriorityClassName |
 | machine.replicaCount | int | `1` | Replicas for Admission Pods |
-| machine.runtime | string | `"containerd"` | Used Runtime |
 | machine.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | machine.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | machine.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
@@ -298,6 +294,7 @@ Available Values for the [Operating System Manager](). The component consists of
 | osm.component.removeManifestsOnDisable | bool | `true` | Remove all manifests on disable in the vcluster (**Attention**: When crds are deleted all crs will be deleted as well) |
 | osm.enabled | bool | `false` | Enable Operating System Manager Component |
 | osm.imagePullSecrets | list | `[]` | Image pull Secrets |
+| osm.kubelet.featureGates | list | `[]` | FeatureGates for kubelet |
 | osm.labels | object | `{}` | Labels for Workload |
 | osm.metrics.enabled | bool | `true` | Enable Metrics |
 | osm.metrics.service.annotations | object | `{}` | Service Annotations |
@@ -314,12 +311,18 @@ Available Values for the [Operating System Manager](). The component consists of
 | osm.metrics.serviceMonitor.namespace | string | `""` | Install the ServiceMonitor into a different Namespace, as the monitoring stack one (default: the release one) |
 | osm.metrics.serviceMonitor.targetLabels | list | `[]` | Set targetLabels for the serviceMonitor |
 | osm.nodeSelector | object | `{}` | Node Selector |
+| osm.pause.image.digest | string | `""` | Image Digest |
+| osm.pause.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| osm.pause.image.registry | string | `""` | Image registry |
+| osm.pause.image.repository | string | `"pause"` | Image repository |
+| osm.pause.image.tag | string | `"3.5"` | Image tag |
 | osm.podAnnotations | object | `{}` | Pod Annotations |
 | osm.podDisruptionBudget | object | `{}` | Configure PodDisruptionBudget |
 | osm.podLabels | object | `{}` | Pod Labels |
 | osm.podSecurityContext | object | `{"enabled":true,"runAsNonRoot":false,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod Security Context |
 | osm.priorityClassName | string | `""` | Pod PriorityClassName |
 | osm.replicaCount | int | `1` | Replicas for Admission Pods |
+| osm.runtime | string | `"containerd"` | Used Runtime |
 | osm.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | osm.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | osm.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |

--- a/charts/vcluster/ci/registry-mirrors.yaml
+++ b/charts/vcluster/ci/registry-mirrors.yaml
@@ -1,0 +1,16 @@
+global:
+  # Image Registries
+  registries:
+    # -- Default Registry (used for kubeadm, node-registry-mirrors etc.)
+    primary:
+      # -- Registry Endpoint
+      endpoint: "docker.io"
+      creds:
+        # -- Registry Username
+        username: "foo"
+        # -- Registry Password
+        password: "bar"
+    # -- Registry Mirrors (used for containerd config)
+    mirrors:
+      # -- Key: mirror URL, Value: path in primary registry
+      ghcr.io: "/ghcr"

--- a/charts/vcluster/ci/registry-primary-only.yaml
+++ b/charts/vcluster/ci/registry-primary-only.yaml
@@ -1,0 +1,12 @@
+global:
+  # Image Registries
+  registries:
+    # -- Default Registry (used for kubeadm, node-registry-mirrors etc.)
+    primary:
+      # -- Registry Endpoint
+      endpoint: "docker.io"
+      creds:
+        # -- Registry Username
+        username: "foo"
+        # -- Registry Password
+        password: "bar"

--- a/charts/vcluster/ci/registry-secondary.yaml
+++ b/charts/vcluster/ci/registry-secondary.yaml
@@ -1,0 +1,19 @@
+global:
+  # Image Registries
+  registries:
+    # -- Default Registry (used for kubeadm, node-registry-mirrors etc.)
+    primary:
+      # -- Registry Endpoint
+      endpoint: "docker.io"
+      creds:
+        # -- Registry Username
+        username: "foo"
+        # -- Registry Password
+        password: "bar"
+    # -- Additional Registries (used in regcred secret)
+    secondaries:
+      # -- Key: registry url
+      ghcr.io:
+        creds:
+          username: "foo"
+          password: "baz"

--- a/charts/vcluster/templates/components/machine-controller/_templates.tpl
+++ b/charts/vcluster/templates/components/machine-controller/_templates.tpl
@@ -23,7 +23,7 @@ Component Manifests directory
 {{- end }}
 
 {{/*
-Component Manifests directory
+Component Manifests
 */}}
 {{- define "machine-controller.manifests" -}}
 {{- printf "%s/**.yaml" (include "machine-controller.manifests.dir" $) -}}
@@ -36,9 +36,8 @@ Component Webhook directory
 {{- printf "webhooks/%s" (include "machine-controller.component" $) -}}
 {{- end }}
 
-
 {{/*
-Component Webhook directory
+Component Webhook
 */}}
 {{- define "machine-controller.webhooks" -}}
 {{- printf "%s/**.yaml" (include "machine-controller.webhooks.dir" $) -}}
@@ -49,13 +48,6 @@ Component Webhook directory
 */}}
 {{- define "machine-controller.component" -}}
 machine-controller
-{{- end }}
-
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "machine-controller.name" -}}
-{{- include "machine-controller.component" $ -}}
 {{- end }}
 
 {{/*
@@ -109,7 +101,6 @@ Create the name of the service account to use
   {{- end -}}
 {{- end -}}
 
-
 {{/*
 Create the Admission Webhook TLS Secret
 */}}
@@ -148,49 +139,8 @@ checksum/webhooks: {{ (.Files.Glob (include "machine-controller.webhooks" $) | t
 */}}
 {{- define "machine-controller.controller.args" -}}
 - -kubeconfig={{ include "pkg.cluster.cp.env.mount" $ }}
-  {{- if (include "pkg.common.proxy.enabled" $) }}
-    {{- with (include "pkg.common.proxy.host" $) }}
-- -node-http-proxy={{ . }}
-      {{- with (include "pkg.common.proxy.no_proxy" $) }}
-- -node-no-proxy={{ . | quote }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- if (include "pkg.images.registry.set" $) }}
-- -node-registry-mirrors={{ include "pkg.images.registry.url" $ }}
-#- -node-containerd-registry-mirrors
-    {{- if (include "pkg.images.registry.auth" $) }}
-- -node-registry-credentials-secret={{ include "pkg.images.registry.secretnamespace" $ }}/regcreds
-    {{- end }}
-  {{- end }}
-- -cluster-dns={{ include "kubernetes.getCoreDNS" $ }}
 - -override-bootstrap-kubelet-apiserver={{ include "kubernetes.api.endpoint" $ }}
-  {{- with $.Values.machine.kubelet.featureGates }}
-- -node-kubelet-feature-gates={{ . | join "," | quote }}
-  {{- end }}
 {{- end -}}
-
-{{/*
-    Pause Image / OSM Compatible
-*/}}
-{{- define "machine-controller.pause" -}}
-{{- $machine := $.Values.machine -}}
-  {{- with $machine.pause }}
-    {{- include "pkg.images.registry.convert" (dict "image" .image "ctx" $) -}}
-  {{- end }}
-{{- end }}
-
-
-{{/*
-    Runtime / OSM Compatible
-*/}}
-{{- define "machine-controller.runtime" -}}
-{{- $machine := $.Values.machine -}}
-  {{- with $machine.runtime }}
-    {{- printf "%s" . -}}
-  {{- end }}
-{{- end }}
-
 
 {{/*
 Create the Admission Webhook Name
@@ -212,7 +162,7 @@ machine-controller-mutating-webhook
     {{- if (include "machine-controller.admission.expose.ingress" $) -}}
       {{- $base = (printf "https://%s/%s" (include "pkg.components.ingress.host" $) (include "machine-controller.admission.expose.ingress.context" $ | trimPrefix "/")) -}}
     {{- end -}}
-  
+
     {{/* Expose via Service (LoadBalancer) */}}
     {{- if (include "machine-controller.admission.expose.loadbalancer" $) -}}
       {{- $base = (printf "https://%s:%s" (include "machine-controller.admission.expose.loadbalancer.ip" $) (include "machine-controller.admission.expose.loadbalancer.port" $)) -}}
@@ -250,7 +200,6 @@ Admission Expose
   {{- end -}}
 {{- end -}}
 
-
 {{- define "machine-controller.admission.expose.loadbalancer.ip" -}}
   {{- $machine := $.Values.machine -}}
   {{- with $machine.admission.service.loadBalancerIP -}}
@@ -276,7 +225,6 @@ Admission Expose
   {{- $machine := $.Values.machine -}}
   {{- printf "%s" (required "Context Required" $machine.admission.ingress.contextPath) -}}
 {{- end -}}
-
 
 {{/* Volumes for Admission Pod */}}
 {{- define "machine-controller.volumes" -}}
@@ -338,7 +286,6 @@ Admission Expose
   {{- include "machine-controller.manifest-create" $ | nindent 0 }}
   {{- include "machine-controller.admission.webhook-cert-patch" $ | nindent 0 }}
 {{- end -}}
-
 
 {{/*
   Ensure Manifests

--- a/charts/vcluster/templates/components/machine-controller/deployment.yaml
+++ b/charts/vcluster/templates/components/machine-controller/deployment.yaml
@@ -77,15 +77,6 @@ spec:
             {{- include "machine-controller.controller.args" $ | nindent 12 }}
             - -metrics-address=0.0.0.0:8080
             - -health-probe-address=0.0.0.0:8085
-            {{- if (include "operating-system-manager.enabled" $) }}
-            - -use-external-bootstrap
-            {{- end }}
-            {{- with (include "machine-controller.runtime" $) }}
-            - -node-container-runtime={{ . }}
-            {{- end }}
-            {{- with (include "machine-controller.pause" $) }}
-            - -node-pause-image={{ . }}
-            {{- end }}
             {{- with .args }}
               {{- include "pkg.utils.args" (dict "args" . "ctx" $) | nindent 12 }}
             {{- end }}

--- a/charts/vcluster/templates/components/operating-system-manager/deployment.yaml
+++ b/charts/vcluster/templates/components/operating-system-manager/deployment.yaml
@@ -72,13 +72,13 @@ spec:
           command:
             - /usr/local/bin/osm-controller
             - -namespace=kube-system
-            {{- include "machine-controller.controller.args" $ | nindent 12 }}
+            {{- include "operating-system-manager.controller.args" $ | nindent 12 }}
             - -metrics-address=0.0.0.0:8080
             - -health-probe-address=0.0.0.0:8085
-            {{- with (include "machine-controller.runtime" $) }}
+            {{- with (include "operating-system-manager.runtime" $) }}
             - -container-runtime={{ . }}
             {{- end }}
-            {{- with (include "machine-controller.pause" $) }}
+            {{- with (include "operating-system-manager.pause" $) }}
             - -pause-image={{ . }}
             {{- end }}
             {{- with .args }}

--- a/charts/vcluster/values.yaml
+++ b/charts/vcluster/values.yaml
@@ -6,15 +6,28 @@ global:
     # -- No Proxy Hosts
     no_proxy: "10.0.0.0/8"
 
-  # Docker Registry
-  registry:
-    # -- Registry Endpoint
-    endpoint: ""
-    creds:
-      # -- Registry Username
-      username: ""
-      # -- Registry Password
-      password: ""
+  # Image Registries
+  registries:
+    # -- Default Registry (used for kubeadm, node-registry-mirrors etc.)
+    primary:
+      # -- Registry Endpoint
+      endpoint: ""
+      creds:
+        # -- Registry Username
+        username: ""
+        # -- Registry Password
+        password: ""
+    # -- Additional Registries (used in regcred secret)
+    secondaries: {}
+      # -- Key: registry url
+      # docker.io:
+      #   creds:
+      #     username: ""
+      #     password: ""
+    # -- Registry Mirrors (used for containerd config)
+    mirrors: {}
+      # -- Key: mirror URL, Value: path in primary registry
+      # docker.io: "/dockerhub"
 
   # -- StorageClassName for all persistent volumes
   storageClassName: ""
@@ -370,29 +383,6 @@ machine:
   # -- Tag Version used for machine-controller components
   version: "v1.57.0"
 
-  # Kubelet Configuration
-  kubelet:
-    # -- FeatureGates for kubelet
-    featureGates: []
-    # RotateKubeletServerCertificate=true
-
-  # -- Used Runtime
-  runtime: containerd
-
-  # Pause Image (Required on each machine)
-  pause:
-    image:
-      # -- Image registry
-      registry: ""
-      # -- Image repository
-      repository: pause
-      # -- Image pull policy
-      pullPolicy: IfNotPresent
-      # -- Image tag
-      tag: "3.5"
-      # -- Image Digest
-      digest: ""
-
   # Controller Component
   controller:
     # -- Controller Command Arguments ([See Available](https://github.com/kubermatic/machine-controller/blob/main/cmd/machine-controller/main.go))
@@ -690,6 +680,29 @@ osm:
 
   # -- Tag Version used for both components
   version: "v1.3.0"
+
+  # Kubelet Configuration
+  kubelet:
+    # -- FeatureGates for kubelet
+    featureGates: []
+    # RotateKubeletServerCertificate=true
+
+  # -- Used Runtime
+  runtime: containerd
+
+  # Pause Image (Required on each machine)
+  pause:
+    image:
+      # -- Image registry
+      registry: ""
+      # -- Image repository
+      repository: pause
+      # -- Image pull policy
+      pullPolicy: IfNotPresent
+      # -- Image tag
+      tag: "3.5"
+      # -- Image Digest
+      digest: ""
 
   # Controller Component
   controller:

--- a/ct.yaml
+++ b/ct.yaml
@@ -14,4 +14,3 @@ validate-yaml: true
 exclude-deprecated: true
 excluded-charts:
   - "manifests"
-  - "vcluster"


### PR DESCRIPTION
**What this PR does**:

- Add option to provide additional pull registries
- Add option to set mirror registries to operating-system-manager
- Remove obsolete cli flags of machine-controller
- Enable chart-testing for vcluster

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
