### PR TITLE
[vcluster]: remove deprecated environment variable of etcd named ETCDCTL_API

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/templates/components/kubernetes/etcd/backup-job.yaml
+++ b/charts/vcluster/templates/components/kubernetes/etcd/backup-job.yaml
@@ -102,8 +102,6 @@ spec:
             {{- else }}
               {{- include "pkg.common.env" $ | nindent 12 }}
             {{- end }}
-            - name: ETCDCTL_API
-              value: "3"
             - name: ETCDCTL_CACERT
               value: /pki/etcd/peer/ca.crt
             - name: ETCDCTL_CERT

--- a/charts/vcluster/templates/components/kubernetes/etcd/statefulset.yaml
+++ b/charts/vcluster/templates/components/kubernetes/etcd/statefulset.yaml
@@ -115,8 +115,6 @@ spec:
         {{- else }}
           {{- include "pkg.common.env" $ | nindent 8 }}
         {{- end }}
-        - name: ETCDCTL_API
-          value: "3"
         - name: ETCDCTL_CACERT
           value: /pki/etcd/peer/ca.crt
         - name: ETCDCTL_CERT


### PR DESCRIPTION
**What this PR does**:

Removes environment variable ETCDCTL_API which throws an error whenever etcdctl is invoked:
`{"level":"warn","ts":"2025-09-29T12:25:49.209501+0200","caller":"flags/flag.go:94","msg":"unrecognized environment variable","environment-variable":"ETCDCTL_API=3"}`

**Notes for Reviewer**:

https://github.com/etcd-io/etcd/pull/9784

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
