### PR TITLE
[vcluster]: remove bitnami common subchart, add optional etcd defragmentation CronJob

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -13,7 +13,3 @@ home: https://artifacthub.io/packages/helm/kvaps/kubernetes
 maintainers:
   - name: "Bedag Informatik AG"
     email: sre@bedag.ch
-dependencies:
-  - name: common
-    version: 2.14.1
-    repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.13.1
+version: 0.14.0
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 
@@ -656,6 +656,34 @@ Deploys [ETCD](https://etcd.io/).
 | kubernetes.etcd.cleanup.tolerations | list | `[]` | Tolerations |
 | kubernetes.etcd.cleanup.topologySpreadConstraints | list | `[]` | TopologySpreadConstraints for all workloads |
 | kubernetes.etcd.cleanup.ttlSecondsAfterFinished | int | `120` | ttlSecondsAfterFinished for ETCD Backup Cleanup |
+| kubernetes.etcd.defrag.affinity | object | `{}` | Affinity |
+| kubernetes.etcd.defrag.annotations | object | `{}` | Annotations for Workload |
+| kubernetes.etcd.defrag.defragRule | string | `"dbQuotaUsage > 0.8 || dbSize - dbSizeInUse > 200*1024*1024"` | defrag-rule for ETCD Defragmentation (https://github.com/ahrtr/etcd-defrag?tab=readme-ov-file#defragmentation-rule) |
+| kubernetes.etcd.defrag.enabled | bool | `false` | Enable ETCD Defragmentation |
+| kubernetes.etcd.defrag.envs | object | `{}` | Extra environment variables (`key: value` style, allows templating) |
+| kubernetes.etcd.defrag.envsFrom | list | `[]` | Extra environment variables from |
+| kubernetes.etcd.defrag.failedJobsHistoryLimit | int | `3` | Failed Jobs History Limit for ETCD Defragmentation |
+| kubernetes.etcd.defrag.image.digest | string | `""` | Image Digest |
+| kubernetes.etcd.defrag.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| kubernetes.etcd.defrag.image.registry | string | `"ghcr.io"` | Image registry |
+| kubernetes.etcd.defrag.image.repository | string | `"ahrtr/etcd-defrag"` | Image repository |
+| kubernetes.etcd.defrag.image.tag | string | `"v0.18.0"` | Image tag |
+| kubernetes.etcd.defrag.imagePullSecrets | list | `[]` | Image pull Secrets |
+| kubernetes.etcd.defrag.injectProxy | bool | `false` | Inject Proxy as Environment Variables |
+| kubernetes.etcd.defrag.labels | object | `{}` | Labels for Workload |
+| kubernetes.etcd.defrag.nodeSelector | object | `{}` | Node Selector |
+| kubernetes.etcd.defrag.podAnnotations | object | `{}` | Pod Annotations |
+| kubernetes.etcd.defrag.podLabels | object | `{}` | Pod Labels |
+| kubernetes.etcd.defrag.podSecurityContext | object | `{"enabled":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod Security Context |
+| kubernetes.etcd.defrag.priorityClassName | string | `""` | Pod PriorityClassName |
+| kubernetes.etcd.defrag.resources | object | `{}` | Pod Requests and limits |
+| kubernetes.etcd.defrag.restartPolicy | string | `"OnFailure"` | Restart Policy for ETCD Defragmentation |
+| kubernetes.etcd.defrag.schedule | string | `"0 0 1 * *"` | Schedule for ETCD Defragmentation |
+| kubernetes.etcd.defrag.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"readOnlyRootFilesystem":true}` | Container Security Context |
+| kubernetes.etcd.defrag.successfulJobsHistoryLimit | int | `3` | Successful Jobs History Limit for ETCD Defragmentation |
+| kubernetes.etcd.defrag.tolerations | list | `[]` | Tolerations |
+| kubernetes.etcd.defrag.topologySpreadConstraints | list | `[]` | TopologySpreadConstraints for all workloads |
+| kubernetes.etcd.defrag.ttlSecondsAfterFinished | int | `120` | ttlSecondsAfterFinished for ETCD Defragmentation |
 | kubernetes.etcd.enabled | bool | `true` | Enable ETCD |
 | kubernetes.etcd.envs | object | `{}` | Extra environment variables (`key: value` style, allows templating) |
 | kubernetes.etcd.envsFrom | list | `[]` | Extra environment variables from |

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -14,12 +14,6 @@ Virtual Kubernetes Cluster
 | ---- | ------ | --- |
 | Bedag Informatik AG | <sre@bedag.ch> |  |
 
-## Requirements
-
-| Repository | Name | Version |
-|------------|------|---------|
-| oci://registry-1.docker.io/bitnamicharts | common | 2.14.1 |
-
 # Major Changes
 
 Major Changes to functions are documented with the version affected. **Before upgrading the dependency version, check this section out!**

--- a/charts/vcluster/templates/components/autoscaler/hpa.yaml
+++ b/charts/vcluster/templates/components/autoscaler/hpa.yaml
@@ -2,7 +2,7 @@
   {{- $manifest := $.Values.autoscaler.autoscaling -}}
   {{- if $manifest.enabled }}
 ---
-apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "autoscaler.fullname" $ }}

--- a/charts/vcluster/templates/components/autoscaler/pdb.yaml
+++ b/charts/vcluster/templates/components/autoscaler/pdb.yaml
@@ -2,7 +2,7 @@
   {{- $manifest := $.Values.autoscaler -}}
   {{- if $manifest.podDisruptionBudget -}}
 ---
-apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "autoscaler.fullname" . }}

--- a/charts/vcluster/templates/components/kubernetes/apiserver/hpa.yaml
+++ b/charts/vcluster/templates/components/kubernetes/apiserver/hpa.yaml
@@ -6,7 +6,7 @@
     {{- $manifest := $kubernetes.apiServer.autoscaling -}}
     {{- if $manifest.enabled }}
 ---
-apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: "{{ $fullName }}-apiserver"

--- a/charts/vcluster/templates/components/kubernetes/apiserver/pdb.yaml
+++ b/charts/vcluster/templates/components/kubernetes/apiserver/pdb.yaml
@@ -5,7 +5,7 @@
     {{- $component_name := "apiserver" -}}
     {{- if $kubernetes.apiServer.podDisruptionBudget -}}
 ---
-apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ $fullName }}-apiserver"

--- a/charts/vcluster/templates/components/kubernetes/controller-manager/hpa.yaml
+++ b/charts/vcluster/templates/components/kubernetes/controller-manager/hpa.yaml
@@ -6,7 +6,7 @@
     {{- $manifest := $kubernetes.controllerManager.autoscaling -}}
     {{- if $manifest.enabled }}
 ---
-apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: "{{ $fullName }}-controller-manager"

--- a/charts/vcluster/templates/components/kubernetes/controller-manager/pdb.yaml
+++ b/charts/vcluster/templates/components/kubernetes/controller-manager/pdb.yaml
@@ -5,7 +5,7 @@
     {{- $component_name := "controller-manager" -}}
     {{- if $kubernetes.controllerManager.podDisruptionBudget -}}
 ---
-apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ $fullName }}-controller-manager"

--- a/charts/vcluster/templates/components/kubernetes/etcd/defrag-job.yaml
+++ b/charts/vcluster/templates/components/kubernetes/etcd/defrag-job.yaml
@@ -1,0 +1,132 @@
+{{- if (include "kubernetes.enabled" $) -}}
+  {{- $kubernetes := $.Values.kubernetes -}}
+  {{- if and $kubernetes.etcd.enabled $kubernetes.etcd.defrag.enabled -}}
+    {{- $fullName := include "kubernetes.fullname" . -}}
+    {{- $component_name := "etcd" -}}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $fullName }}-etcd-defrag
+  labels: {{- include "kubernetes.labels" $ | nindent 4 }}
+    {{ include "pkg.common.labels.component" $ }}: {{ $component_name }}
+    {{- with (include "pkg.components.labels" (dict "labels" $kubernetes.etcd.defrag.labels "ctx" $)) }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with (include "pkg.components.annotations" (dict "annotations" $kubernetes.etcd.defrag.annotations "ctx" $)) }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  schedule: "{{ $kubernetes.etcd.defrag.schedule }}"
+  successfulJobsHistoryLimit: {{ $kubernetes.etcd.defrag.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $kubernetes.etcd.defrag.failedJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{ include "pkg.common.labels.component" $ }}: {{ $component_name }}
+        {{- with (include "pkg.components.labels" (dict "labels" $kubernetes.etcd.defrag.labels "ctx" $)) }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with (include "pkg.components.annotations" (dict "annotations" $kubernetes.etcd.defrag.annotations "ctx" $)) }}
+      annotations:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with $kubernetes.etcd.defrag.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ . }}
+      {{- end }}
+      template:
+        metadata:
+          labels: {{- include "kubernetes.labels" $ | nindent 12 }}
+            {{- include "pkg.components.pod_labels" (dict "labels" $kubernetes.etcd.defrag.podLabels "ctx" $) | nindent 12 }}
+            {{ include "pkg.common.labels.component" $ }}: {{ $component_name }}
+          annotations:
+            {{- include "pkg.components.pod_annotations" (dict "annotations" $kubernetes.etcd.defrag.podAnnotations "ctx" $) | nindent 12 }}
+        spec:
+          {{- with (include "pkg.components.nodeselector" (dict "nodeSelector" $kubernetes.etcd.defrag.nodeSelector "ctx" $)) }}
+          nodeSelector: {{- . | nindent 12 }}
+          {{- end }}
+          {{- with (include "pkg.components.tolerations" (dict "tolerations" $kubernetes.etcd.defrag.tolerations "ctx" $)) }}
+          tolerations:  {{- . | nindent 12 }}
+          {{- end }}
+          {{- with (include "pkg.components.priorityClass" (dict "pc" $kubernetes.etcd.defrag.priorityClassName "ctx" $)) }}
+          priorityClassName: {{ . }}
+          {{- end }}
+          {{- with (include "pkg.components.topologySpreadConstraints" (dict "tsc" $kubernetes.etcd.defrag.topologySpreadConstraints "ctx" $)) }}
+          topologySpreadConstraints: {{ . | nindent 12 }}
+          {{- end }}
+          affinity:
+          {{- with (include "pkg.components.affinity" (dict "affinity" $kubernetes.etcd.defrag.affinity "ctx" $)) }}
+            {{- . | nindent 10 }}
+          {{- end }}
+          {{- if eq $kubernetes.etcd.defrag.podAntiAffinity "hard" }}
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: "{{ $kubernetes.etcd.defrag.podAntiAffinityTopologyKey }}"
+                  labelSelector:
+                    matchLabels:
+                      app: {{ $fullName }}-etcd
+          {{- else if eq $kubernetes.etcd.defrag.podAntiAffinity "soft" }}
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  podAffinityTerm:
+                    topologyKey: "{{ $kubernetes.etcd.defrag.podAntiAffinityTopologyKey }}"
+                    labelSelector:
+                      matchLabels:
+                        app: {{ $fullName }}-etcd
+          {{- end }}
+          imagePullSecrets: {{- include "pkg.images.registry.pullsecrets" $ | nindent 10 }}
+            {{- with $kubernetes.etcd.defrag.imagePullSecrets }}
+              {{- toYaml . | nindent 10 }}
+            {{- end }}
+          automountServiceAccountToken: false
+          restartPolicy: {{ $kubernetes.etcd.defrag.restartPolicy }}
+          containers:
+          - args:
+            - --endpoints={{ template "kubernetes.etcdCtlEndpoints" . }}
+            - --cacert=/pki/etcd/peer/ca.crt
+            - --cert=/pki/etcd/peer/tls.crt
+            - --key=/pki/etcd/peer/tls.key
+            - --cluster
+            - --defrag-rule
+            {{- with $kubernetes.etcd.defrag.defragRule }}
+            - {{ . | quote }}
+            {{- end }}
+            {{- with $kubernetes.etcd.defrag.envsFrom }}
+            envFrom:
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            env:
+            {{- if $kubernetes.etcd.defrag.injectProxy }}
+              {{- include "pkg.common.env.w-proxy" $ | nindent 12 }}
+            {{- else }}
+              {{- include "pkg.common.env" $ | nindent 12 }}
+            {{- end }}
+            {{- with $kubernetes.etcd.defrag.envs }}
+              {{- include "pkg.utils.envs" (dict "envs" . "ctx" $) | nindent 12 }}
+            {{- end }}
+            {{- with $kubernetes.etcd.defrag.image }}
+            image: {{ include "pkg.images.registry.convert" (dict "image" . "ctx" $) }}
+            imagePullPolicy: {{ include "pkg.images.registry.pullpolicy" (dict "policy" .pullPolicy "ctx" $) }}
+            {{- end }}
+            name: etcd-defrag
+            {{- with (include "pkg.components.securityContext" (dict "sc" $kubernetes.etcd.defrag.securityContext "ctx" $)) }}
+            securityContext: {{ . | nindent 14 }}
+            {{- end }}
+            resources:
+              {{- toYaml $kubernetes.etcd.defrag.resources | nindent 14 }}
+            volumeMounts:
+            - mountPath: /pki/etcd/peer
+              name: pki-etcd-certs-peer
+          {{- with (include "pkg.components.podSecurityContext" (dict "psc" $kubernetes.etcd.defrag.podSecurityContext "ctx" $)) }}
+          securityContext: {{ . | nindent 12 }}
+          {{- end }}
+          volumes:
+          - secret:
+              secretName: {{ $fullName }}-pki-etcd-peer
+            name: pki-etcd-certs-peer
+  {{- end -}}
+{{- end -}}

--- a/charts/vcluster/templates/components/kubernetes/etcd/pdb.yaml
+++ b/charts/vcluster/templates/components/kubernetes/etcd/pdb.yaml
@@ -5,7 +5,7 @@
     {{- $component_name := "etcd" -}}
     {{- if $kubernetes.etcd.podDisruptionBudget -}}
 ---
-apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ $fullName }}-etcd"

--- a/charts/vcluster/templates/components/kubernetes/scheduler/hpa.yaml
+++ b/charts/vcluster/templates/components/kubernetes/scheduler/hpa.yaml
@@ -6,7 +6,7 @@
     {{- $manifest := $kubernetes.scheduler.autoscaling -}}
     {{- if $manifest.enabled }}
 ---
-apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: "{{ $fullName }}-scheduler"

--- a/charts/vcluster/templates/components/kubernetes/scheduler/pdb.yaml
+++ b/charts/vcluster/templates/components/kubernetes/scheduler/pdb.yaml
@@ -5,7 +5,7 @@
     {{- $component_name := "scheduler" -}}
     {{- if $kubernetes.scheduler.podDisruptionBudget -}}
 ---
-apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ $fullName }}-scheduler"

--- a/charts/vcluster/templates/components/machine-controller/hpa.yaml
+++ b/charts/vcluster/templates/components/machine-controller/hpa.yaml
@@ -3,7 +3,7 @@
   {{- $manifest := $machine.autoscaling -}}
   {{- if $manifest.enabled }}
 ---
-apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "machine-controller.fullname" . }}

--- a/charts/vcluster/templates/components/machine-controller/pdb.yaml
+++ b/charts/vcluster/templates/components/machine-controller/pdb.yaml
@@ -2,7 +2,7 @@
   {{- $manifest := $.Values.machine -}}
   {{- if $manifest.podDisruptionBudget -}}
 ---
-apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "machine-controller.fullname" . }}

--- a/charts/vcluster/templates/components/operating-system-manager/hpa.yaml
+++ b/charts/vcluster/templates/components/operating-system-manager/hpa.yaml
@@ -3,7 +3,7 @@
   {{- $manifest := $osm.autoscaling -}}
   {{- if $manifest.enabled }}
 ---
-apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "operating-system-manager.fullname" . }}

--- a/charts/vcluster/templates/components/operating-system-manager/pdb.yaml
+++ b/charts/vcluster/templates/components/operating-system-manager/pdb.yaml
@@ -2,7 +2,7 @@
   {{- $manifest := $.Values.osm -}}
   {{- if $manifest.podDisruptionBudget -}}
 ---
-apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "operating-system-manager.fullname" . }}

--- a/charts/vcluster/values.yaml
+++ b/charts/vcluster/values.yaml
@@ -1496,6 +1496,79 @@ kubernetes:
       # -- TopologySpreadConstraints for all workloads
       topologySpreadConstraints: []
 
+    # ETCD Defragmentation
+    defrag:
+      # -- Enable ETCD Defragmentation
+      enabled: false
+      # -- defrag-rule for ETCD Defragmentation (https://github.com/ahrtr/etcd-defrag?tab=readme-ov-file#defragmentation-rule)
+      defragRule: "dbQuotaUsage > 0.8 || dbSize - dbSizeInUse > 200*1024*1024"
+      # -- Schedule for ETCD Defragmentation
+      schedule: "0 0 1 * *"
+      # -- Successful Jobs History Limit for ETCD Defragmentation
+      successfulJobsHistoryLimit: 3
+      # -- Failed Jobs History Limit for ETCD Defragmentation
+      failedJobsHistoryLimit: 3
+      # -- ttlSecondsAfterFinished for ETCD Defragmentation
+      ttlSecondsAfterFinished: 120
+      # -- Restart Policy for ETCD Defragmentation
+      restartPolicy: OnFailure
+      # Image
+      image:
+        # -- Image registry
+        registry: ghcr.io
+        # -- Image repository
+        repository: ahrtr/etcd-defrag
+        # -- Image tag
+        tag: v0.18.0
+        # -- Image Digest
+        digest: ""
+        # -- Image pull policy
+        pullPolicy: IfNotPresent
+      # -- Image pull Secrets
+      imagePullSecrets: []
+      # -- Pod Requests and limits
+      resources: {}
+      # -- Labels for Workload
+      labels: {}
+      # -- Annotations for Workload
+      annotations: {}
+      # -- Pod Labels
+      podLabels: {}
+      # -- Pod Annotations
+      podAnnotations: {}
+      # -- Extra environment variables (`key: value` style, allows templating)
+      envs: {}
+      # -- Extra environment variables from
+      envsFrom: []
+      # -- Inject Proxy as Environment Variables
+      injectProxy: false
+      # -- Pod Security Context
+      podSecurityContext:
+        enabled: true
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      # -- Container Security Context
+      securityContext:
+        enabled: true
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+          - ALL
+      # -- Node Selector
+      nodeSelector: {}
+      # -- Tolerations
+      tolerations: []
+      podAntiAffinity: soft
+      podAntiAffinityTopologyKey: kubernetes.io/hostname
+      # -- Affinity
+      affinity: {}
+      # -- Pod PriorityClassName
+      priorityClassName: ""
+      # -- TopologySpreadConstraints for all workloads
+      topologySpreadConstraints: []
+
   ## Kubernetes API-Server
   apiServer:
     # -- Enable Kubernetes API-Server


### PR DESCRIPTION
**What this PR does**:

- Remove helm chart dependency bitnami/common
- Adds optional etcd defragmentation CronJob as suggested in https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/#cluster-defragmentation

**Notes for Reviewer**:

Based on etcd-defrag: https://github.com/ahrtr/etcd-defrag

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
