### PR TITLE
[common]: Add externalRefs registry for reusable external dependencies

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -28,13 +28,13 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: added
-      description: "externalRefs: unified registry for ConfigMaps, Secrets, PVCs, and ExternalName services (list format with id field)"
+      description: "externalRefs: unified registry for ConfigMaps, Secrets, PVCs, and Services (list format with id field)"
     - kind: added
-      description: "externalRefs: ExternalName kind support with mode create (chart-managed) and reference (pre-existing)"
+      description: "externalRefs: Service kind support with mode create (ExternalName service) and reference (pre-existing service)"
     - kind: added
-      description: "externalRefs: new externalServiceRef env field resolves ExternalName service names in container env vars"
+      description: "externalRefs: new externalServiceRef env field resolves referenced service names in container env vars"
     - kind: added
-      description: "externalRefs: mode field (create/reference) for ExternalName entries"
+      description: "externalRefs: mode field (create/reference) for Service entries"
     - kind: added
       description: "externalRef support for envFrom, volumes, env valueFrom secretKeyRef/configMapKeyRef"
     - kind: added
@@ -56,4 +56,4 @@ annotations:
     - kind: changed
       description: "DX: title properties on oneOf schema branches for clearer validation error messages"
     - kind: removed
-      description: "Removed standalone externalNameServices section (merged into externalRefs with kind: ExternalName)"
+      description: "Removed standalone externalNameServices section (merged into externalRefs with kind: Service)"

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 12.6.0
+version: 12.7.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -27,5 +27,33 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
-    - "[Changed]: extra annotations and labels support sprig statements"
-    - "[Added]: Possibility to optionally set appVersion in values"
+    - kind: added
+      description: "externalRefs: unified registry for ConfigMaps, Secrets, PVCs, and ExternalName services (list format with id field)"
+    - kind: added
+      description: "externalRefs: ExternalName kind support with mode create (chart-managed) and reference (pre-existing)"
+    - kind: added
+      description: "externalRefs: new externalServiceRef env field resolves ExternalName service names in container env vars"
+    - kind: added
+      description: "externalRefs: mode field (create/reference) for ExternalName entries"
+    - kind: added
+      description: "externalRef support for envFrom, volumes, env valueFrom secretKeyRef/configMapKeyRef"
+    - kind: added
+      description: "externalRef support for ServiceMonitor basicAuth existingSecret"
+    - kind: added
+      description: "externalRef support for Ingress TLS secretName resolution with auto-inferred tls.type"
+    - kind: added
+      description: "externalRef support for imagePullSecrets registry pull secret name"
+    - kind: added
+      description: "externalRefs registry: optional group and version fields for GVK support"
+    - kind: changed
+      description: "includes.externalRefs replaces includes.externalNameService as the feature toggle"
+    - kind: changed
+      description: "DX: externalRef is nested under parent field (secretName, existingSecret, name) for Ingress TLS, ServiceMonitor basicAuth, and imagePullSecrets"
+    - kind: changed
+      description: "Validation hardening: shared helper for string-or-externalRef field validation with path-aware error messages"
+    - kind: changed
+      description: "Validation hardening: volumes with empty externalRef fail fast instead of being silently dropped"
+    - kind: changed
+      description: "DX: title properties on oneOf schema branches for clearer validation error messages"
+    - kind: removed
+      description: "Removed standalone externalNameServices section (merged into externalRefs with kind: ExternalName)"

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -25,7 +25,7 @@ Major Changes to functions are documented with the version affected. **Before up
 |networkpolicy template changes|10.0.0|add possibility to create multiple networkpolicies|https://github.com/bedag/helm-charts/pull/77|
 |ingress template changes|11.0.0|add possibility to create multiple ingress objects|https://github.com/bedag/helm-charts/pull/134
 |ingress template changes|12.0.0|support defining multiple hosts and secrets for one ingress|https://github.com/bedag/helm-charts/pull/138
-|unified externalRefs|12.7.0|List-based externalRefs registry for ConfigMaps, Secrets, PVCs, and ExternalName services. Supports `mode: create` (chart-managed) and `mode: reference` (pre-existing). New `externalServiceRef` env field resolves ExternalName service names.|
+|unified externalRefs|12.7.0|List-based externalRefs registry for ConfigMaps, Secrets, PVCs, and Services. Supports `mode: create` (chart-managed ExternalName Service) and `mode: reference` (pre-existing Service). New `externalServiceRef` env field resolves Service names.|
 
 # Values by Component
 
@@ -74,7 +74,7 @@ Major Changes to functions are documented with the version affected. **Before up
 The `externalRefs` feature provides a unified registry for declaring external dependencies at the top level of your values. It supports four resource kinds:
 
 - **ConfigMap** / **Secret** / **PersistentVolumeClaim** — reference pre-existing resources by alias in `envFrom`, `volumes`, `env valueFrom`, Ingress TLS, ServiceMonitor basicAuth, and imagePullSecrets
-- **ExternalName** — create or reference Kubernetes `ExternalName` services for external dependencies (databases, caches, APIs), resolvable in env vars via `externalServiceRef`
+- **Service** — create a Kubernetes `Service` with `spec.type: ExternalName`, or reference an existing Service for external dependencies (databases, caches, APIs), resolvable in env vars via `externalServiceRef`
 
 Enable the feature by setting `includes.externalRefs: true`.
 
@@ -85,14 +85,12 @@ Each entry in the `externalRefs` list supports:
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `id` | Yes | — | Unique alias for referencing this entry |
-| `kind` | Yes | — | Resource kind: `ConfigMap`, `Secret`, `PersistentVolumeClaim`, or `ExternalName` |
-| `mode` | No | `reference` | `reference` (pre-existing resource) or `create` (chart creates the resource). Only `ExternalName` supports `create`. |
+| `kind` | Yes | — | Resource kind: `ConfigMap`, `Secret`, `PersistentVolumeClaim`, or `Service` |
+| `mode` | No | `reference` | `reference` (pre-existing resource) or `create` (chart creates the resource). Only `Service` supports `create`. |
 | `name` | When mode=reference | — | Actual Kubernetes resource name |
-| `externalName` | When kind=ExternalName, mode=create | — | DNS hostname for the ExternalName service |
-| `fullnameOverride` | No | — | Override the generated ExternalName service name entirely (ExternalName + create only) |
-| `annotations` | No | — | Additional annotations for ExternalName services |
-| `group` | No | `""` | API group (empty string for core resources) |
-| `version` | No | `"v1"` | API version |
+| `externalName` | When kind=Service, mode=create | — | DNS hostname for the rendered `Service.spec.externalName` |
+| `fullnameOverride` | No | — | Override the generated Service name entirely (`kind: Service` + `mode: create` only) |
+| `annotations` | No | — | Additional annotations for created Services |
 | `optional` | No | — | Mark the reference as optional |
 
 ### Mode behavior
@@ -100,8 +98,8 @@ Each entry in the `externalRefs` list supports:
 | Kind | Allowed modes | What happens |
 |------|--------------|--------------|
 | ConfigMap / Secret / PVC | `reference` only | No resource created. `name` is used for lookups. |
-| ExternalName | `create` | Chart creates a `Service/ExternalName`. Name = `fullnameOverride` or `<library.name>-<id>`. |
-| ExternalName | `reference` | No resource created. `name` used for `externalServiceRef` resolution. |
+| Service | `create` | Chart creates a `Service` with `spec.type: ExternalName`. Name = `fullnameOverride` or `<library.name>-<id>`. |
+| Service | `reference` | No resource created. `name` used for `externalServiceRef` resolution. |
 
 ### Registry definition
 
@@ -126,24 +124,24 @@ externalRefs:
     kind: PersistentVolumeClaim
     name: shared-data-pvc
 
-  # ExternalName — chart creates the Service
+  # Service — chart creates a Service with spec.type=ExternalName
   - id: database
-    kind: ExternalName
+    kind: Service
     mode: create
     externalName: db.prod.example.com
 
-  # ExternalName — exact name override
+  # Service — exact name override
   - id: cache
-    kind: ExternalName
+    kind: Service
     mode: create
     externalName: cache.prod.example.com
     fullnameOverride: "redis-cache"
     annotations:
       service.beta.kubernetes.io/description: "External Redis cache"
 
-  # ExternalName — reference a pre-existing service
+  # Service — reference a pre-existing service
   - id: partner-api
-    kind: ExternalName
+    kind: Service
     mode: reference
     name: partner-api-gateway
 ```
@@ -192,7 +190,7 @@ controller:
 
 ### externalServiceRef
 
-For `ExternalName` entries, use `externalServiceRef` in env vars to resolve the Kubernetes service name:
+For `Service` entries, use `externalServiceRef` in env vars to resolve the Kubernetes service name:
 
 - **mode: create** — resolves to `fullnameOverride` or `<library.name>-<id>`
 - **mode: reference** — resolves to `name`

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -297,19 +297,16 @@ nameReference:
       - path: spec/values/externalRefs/name
         kind: HelmRelease
         group: helm.toolkit.fluxcd.io
-        version: v2
   - kind: Secret
     fieldSpecs:
       - path: spec/values/externalRefs/name
         kind: HelmRelease
         group: helm.toolkit.fluxcd.io
-        version: v2
   - kind: PersistentVolumeClaim
     fieldSpecs:
       - path: spec/values/externalRefs/name
         kind: HelmRelease
         group: helm.toolkit.fluxcd.io
-        version: v2
 ```
 
 ### Migration from inline refs

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 12.6.0](https://img.shields.io/badge/Version-12.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 12.7.0](https://img.shields.io/badge/Version-12.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 
@@ -25,6 +25,7 @@ Major Changes to functions are documented with the version affected. **Before up
 |networkpolicy template changes|10.0.0|add possibility to create multiple networkpolicies|https://github.com/bedag/helm-charts/pull/77|
 |ingress template changes|11.0.0|add possibility to create multiple ingress objects|https://github.com/bedag/helm-charts/pull/134
 |ingress template changes|12.0.0|support defining multiple hosts and secrets for one ingress|https://github.com/bedag/helm-charts/pull/138
+|unified externalRefs|12.7.0|List-based externalRefs registry for ConfigMaps, Secrets, PVCs, and ExternalName services. Supports `mode: create` (chart-managed) and `mode: reference` (pre-existing). New `externalServiceRef` env field resolves ExternalName service names.|
 
 # Values by Component
 
@@ -45,7 +46,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | ingresses.ingress-1.rules[0].http.paths[0].backend.servicePort | string | `"http"` | servicePort describes the port where the service is listening at (can be either a string or a number) |
 | ingresses.ingress-1.rules[0].http.paths[0].path | string | `"/"` | path which ingress is listening |
 | ingresses.ingress-1.rules[0].http.paths[0].pathType | string | `"ImplementationSpecific"` | pathType Each path in an Ingress is required to have a corresponding path type. Comment out for using default ("ImplementationSpecific") |
-| ingresses.ingress-1.rules[0].secretName | string | `""` | name of existing secrets with tls.crt & tls.key content |
+| ingresses.ingress-1.rules[0].secretName | string | `""` | secretName: name of existing secrets with tls.crt & tls.key content. Can be a plain string or an object with externalRef to resolve from the externalRefs registry. Example: secretName: "my-tls-secret" OR secretName: { externalRef: "app-tls" } |
 | ingresses.ingress-1.tls.provided.cert | string | `""` | If SSL is terminated on ingress and you have a generated (preferrably CERT-001) certificate/key Has to be base64 encoded and should be encrypted in the ejson vault Add Variable to your CI/CD Settings "SKIP_DECRYPT" with value "" that it doesnt decrypt the cert and fails. |
 | ingresses.ingress-1.tls.provided.key | string | `""` | The key must not have a passphrase |
 | ingresses.ingress-1.tls.self | object | `{"alternativeDnsNames":[],"commonName":"*.cluster.local","ipAddresses":[],"validityDuration":365}` | depending on the type you have further configuration options: |
@@ -53,7 +54,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | ingresses.ingress-1.tls.self.commonName | string | `"*.cluster.local"` | commonName of the certificate (mandatory) |
 | ingresses.ingress-1.tls.self.ipAddresses | list | `[]` | ipAddresses is an optional list of IP addresses to add in the Subject Alternative Names (SAN) section |
 | ingresses.ingress-1.tls.self.validityDuration | int | `365` | validityDuration defines how long the certificate is valid (in days) |
-| ingresses.ingress-1.tls.type | string | `"none"` | define your type of tls certificate, it can be one of: none: tls will be disabled existing: use an existing secret already present in the namespace. Requires `secretName` to be specified in `.rules.host` provided: use an officially generated certificate/key k8s: use the default k8s-ingress tls. no further configuration needed self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least |
+| ingresses.ingress-1.tls.type | string | `"none"` | define your type of tls certificate, it can be one of: none: tls will be disabled existing: use an existing secret already present in the namespace. Requires `secretName` to be specified in `.rules.host`.   Auto-inferred when `secretName` is an externalRef object (e.g., `secretName: { externalRef: "app-tls" }`). provided: use an officially generated certificate/key k8s: use the default k8s-ingress tls. no further configuration needed self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least |
 
 ## ServiceMonitor
 
@@ -61,9 +62,284 @@ Major Changes to functions are documented with the version affected. **Before up
 |-----|------|---------|-------------|
 | servicemonitor.basicAuth | object | `{"enabled":false,"existingSecret":"","newSecret":{},"passwordKey":"password","userKey":"username"}` | basicAuth is a dictionary for defining values for setting up basic Authentication |
 | servicemonitor.basicAuth.enabled | bool | `false` | enabled when set to 'true', adds basic authentication to all endpoints |
-| servicemonitor.basicAuth.existingSecret | string | `""` | existingSecret if not empty (""), points to an existing secret (matching name of the resource) |
+| servicemonitor.basicAuth.existingSecret | string | `""` | existingSecret: points to an existing secret (matching name of the resource). Can be a plain string or an object with externalRef to resolve from the externalRefs registry. Example: existingSecret: "my-secret" OR existingSecret: { externalRef: "metrics-creds" } |
 | servicemonitor.basicAuth.newSecret | object | `{}` | newSecret is a dictionary for defining key/value pairs to be stored in a new secret (See `values.yaml`) |
 | servicemonitor.basicAuth.passwordKey | string | `"password"` | passwordKey is the default key to grab the password in the secret |
 | servicemonitor.basicAuth.userKey | string | `"username"` | userKey is the default key to grab the username in the secret |
 | servicemonitor.deploy | bool | `false` | deploy has to be set to true for rendering to be applied |
 | servicemonitor.endpoints | object | `{}` |  |
+
+## externalRefs
+
+The `externalRefs` feature provides a unified registry for declaring external dependencies at the top level of your values. It supports four resource kinds:
+
+- **ConfigMap** / **Secret** / **PersistentVolumeClaim** — reference pre-existing resources by alias in `envFrom`, `volumes`, `env valueFrom`, Ingress TLS, ServiceMonitor basicAuth, and imagePullSecrets
+- **ExternalName** — create or reference Kubernetes `ExternalName` services for external dependencies (databases, caches, APIs), resolvable in env vars via `externalServiceRef`
+
+Enable the feature by setting `includes.externalRefs: true`.
+
+### Fields
+
+Each entry in the `externalRefs` list supports:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `id` | Yes | — | Unique alias for referencing this entry |
+| `kind` | Yes | — | Resource kind: `ConfigMap`, `Secret`, `PersistentVolumeClaim`, or `ExternalName` |
+| `mode` | No | `reference` | `reference` (pre-existing resource) or `create` (chart creates the resource). Only `ExternalName` supports `create`. |
+| `name` | When mode=reference | — | Actual Kubernetes resource name |
+| `externalName` | When kind=ExternalName, mode=create | — | DNS hostname for the ExternalName service |
+| `fullnameOverride` | No | — | Override the generated ExternalName service name entirely (ExternalName + create only) |
+| `annotations` | No | — | Additional annotations for ExternalName services |
+| `group` | No | `""` | API group (empty string for core resources) |
+| `version` | No | `"v1"` | API version |
+| `optional` | No | — | Mark the reference as optional |
+
+### Mode behavior
+
+| Kind | Allowed modes | What happens |
+|------|--------------|--------------|
+| ConfigMap / Secret / PVC | `reference` only | No resource created. `name` is used for lookups. |
+| ExternalName | `create` | Chart creates a `Service/ExternalName`. Name = `fullnameOverride` or `<library.name>-<id>`. |
+| ExternalName | `reference` | No resource created. `name` used for `externalServiceRef` resolution. |
+
+### Registry definition
+
+```yaml
+includes:
+  externalRefs: true
+
+externalRefs:
+  # ConfigMap (reference only)
+  - id: app-config
+    kind: ConfigMap
+    name: my-app-configmap
+
+  # Secret (reference only)
+  - id: app-secrets
+    kind: Secret
+    name: my-app-secrets
+    optional: true
+
+  # PVC (reference only)
+  - id: shared-data
+    kind: PersistentVolumeClaim
+    name: shared-data-pvc
+
+  # ExternalName — chart creates the Service
+  - id: database
+    kind: ExternalName
+    mode: create
+    externalName: db.prod.example.com
+
+  # ExternalName — exact name override
+  - id: cache
+    kind: ExternalName
+    mode: create
+    externalName: cache.prod.example.com
+    fullnameOverride: "redis-cache"
+    annotations:
+      service.beta.kubernetes.io/description: "External Redis cache"
+
+  # ExternalName — reference a pre-existing service
+  - id: partner-api
+    kind: ExternalName
+    mode: reference
+    name: partner-api-gateway
+```
+
+### envFrom (controller-level or container-level)
+
+```yaml
+controller:
+  envFrom:
+    - externalRef: app-config
+    - externalRef: app-secrets
+      optional: false
+```
+
+### volumes
+
+```yaml
+controller:
+  volumes:
+    - name: config-vol
+      externalRef: app-config
+    - name: secret-vol
+      externalRef: app-secrets
+```
+
+### env valueFrom
+
+For list-type `env` entries using `valueFrom.secretKeyRef` or `valueFrom.configMapKeyRef`, use `externalRef` instead of `name` to resolve the resource name from the registry. `secretKeyRef` entries must reference `kind: Secret`, and `configMapKeyRef` must reference `kind: ConfigMap`.
+
+```yaml
+controller:
+  containers:
+    main:
+      env:
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              externalRef: app-secrets
+              key: secret-key
+        - name: CONFIG_VALUE
+          valueFrom:
+            configMapKeyRef:
+              externalRef: app-config
+              key: config-key
+```
+
+### externalServiceRef
+
+For `ExternalName` entries, use `externalServiceRef` in env vars to resolve the Kubernetes service name:
+
+- **mode: create** — resolves to `fullnameOverride` or `<library.name>-<id>`
+- **mode: reference** — resolves to `name`
+
+```yaml
+controller:
+  containers:
+    main:
+      env:
+        - name: DATABASE_HOST
+          externalServiceRef: database
+        - name: PARTNER_API_HOST
+          externalServiceRef: partner-api
+```
+
+### ServiceMonitor basicAuth
+
+When `servicemonitor.basicAuth.enabled` is true, the `existingSecret` field accepts either a plain string or an object with `externalRef` to resolve the secret name. The referenced entry must have `kind: Secret`.
+
+```yaml
+externalRefs:
+  - id: metrics-creds
+    kind: Secret
+    name: my-metrics-credentials
+
+servicemonitor:
+  deploy: true
+  basicAuth:
+    enabled: true
+    existingSecret:
+      externalRef: metrics-creds
+```
+
+### Ingress TLS secretName
+
+The `secretName` field in ingress rules accepts either a plain string or an object with `externalRef`. The referenced entry must have `kind: Secret`.
+
+When `secretName` is an externalRef object, `tls.type` is automatically inferred as `"existing"`.
+
+```yaml
+externalRefs:
+  - id: app-tls
+    kind: Secret
+    name: my-tls-certificate
+
+ingresses:
+  app:
+    deploy: true
+    ingressClassName: nginx
+    rules:
+      - host: app.example.com
+        http:
+          paths:
+            - backend:
+                serviceNameSuffix: my-service
+                servicePort: http
+              path: "/"
+        secretName:
+          externalRef: app-tls
+    tls: {}
+```
+
+### imagePullSecrets
+
+Set `name` to an object with `externalRef` to resolve the pull secret name. The referenced entry must have `kind: Secret`.
+
+```yaml
+externalRefs:
+  - id: registry-creds
+    kind: Secret
+    name: my-registry-credentials
+
+secrets:
+  data:
+    registry:
+      pullSecret:
+        enabled: true
+        name:
+          externalRef: registry-creds
+```
+
+### `optional` precedence
+
+The `optional` field follows this precedence (highest to lowest):
+
+1. **Entry-level**: `optional` set directly on the envFrom/volume entry
+2. **Registry-level**: `optional` set on the externalRefs registry entry
+3. **Omitted**: if neither is set, `optional` is not emitted
+
+### Why a list?
+
+The `externalRefs` registry uses a list (not a map) so that Kustomize `nameReference` transformers can match all entries with a single generic fieldSpec. This is particularly useful with Flux `HelmRelease` resources, where Kustomize can automatically update resource names across all `externalRefs` entries.
+
+Because Kustomize auto-traverses array elements, one `fieldSpecs` path covers every entry regardless of its `id`. A map-based structure would require enumerating each key explicitly, which defeats the purpose.
+
+Example `nameReference` configuration for a Flux `HelmRelease`:
+
+```yaml
+nameReference:
+  - kind: ConfigMap
+    fieldSpecs:
+      - path: spec/values/externalRefs/name
+        kind: HelmRelease
+        group: helm.toolkit.fluxcd.io
+        version: v2
+  - kind: Secret
+    fieldSpecs:
+      - path: spec/values/externalRefs/name
+        kind: HelmRelease
+        group: helm.toolkit.fluxcd.io
+        version: v2
+  - kind: PersistentVolumeClaim
+    fieldSpecs:
+      - path: spec/values/externalRefs/name
+        kind: HelmRelease
+        group: helm.toolkit.fluxcd.io
+        version: v2
+```
+
+### Migration from inline refs
+
+Before (inline):
+
+```yaml
+controller:
+  envFrom:
+    - configMapRef:
+        name: my-app-configmap
+    - secretRef:
+        name: my-app-secrets
+        optional: true
+```
+
+After (alias-based):
+
+```yaml
+externalRefs:
+  - id: app-config
+    kind: ConfigMap
+    name: my-app-configmap
+  - id: app-secrets
+    kind: Secret
+    name: my-app-secrets
+    optional: true
+
+controller:
+  envFrom:
+    - externalRef: app-config
+    - externalRef: app-secrets
+```

--- a/charts/common/README.md.gotmpl
+++ b/charts/common/README.md.gotmpl
@@ -34,7 +34,7 @@ Major Changes to functions are documented with the version affected. **Before up
 |networkpolicy template changes|10.0.0|add possibility to create multiple networkpolicies|https://github.com/bedag/helm-charts/pull/77|
 |ingress template changes|11.0.0|add possibility to create multiple ingress objects|https://github.com/bedag/helm-charts/pull/134
 |ingress template changes|12.0.0|support defining multiple hosts and secrets for one ingress|https://github.com/bedag/helm-charts/pull/138
-|unified externalRefs|12.7.0|List-based externalRefs registry for ConfigMaps, Secrets, PVCs, and ExternalName services. Supports `mode: create` (chart-managed) and `mode: reference` (pre-existing). New `externalServiceRef` env field resolves ExternalName service names.|
+|unified externalRefs|12.7.0|List-based externalRefs registry for ConfigMaps, Secrets, PVCs, and Services. Supports `mode: create` (chart-managed ExternalName Service) and `mode: reference` (pre-existing Service). New `externalServiceRef` env field resolves Service names.|
 {{/*
   Chart Values
 */}}
@@ -71,7 +71,7 @@ Major Changes to functions are documented with the version affected. **Before up
 The `externalRefs` feature provides a unified registry for declaring external dependencies at the top level of your values. It supports four resource kinds:
 
 - **ConfigMap** / **Secret** / **PersistentVolumeClaim** — reference pre-existing resources by alias in `envFrom`, `volumes`, `env valueFrom`, Ingress TLS, ServiceMonitor basicAuth, and imagePullSecrets
-- **ExternalName** — create or reference Kubernetes `ExternalName` services for external dependencies (databases, caches, APIs), resolvable in env vars via `externalServiceRef`
+- **Service** — create a Kubernetes `Service` with `spec.type: ExternalName`, or reference an existing Service for external dependencies (databases, caches, APIs), resolvable in env vars via `externalServiceRef`
 
 Enable the feature by setting `includes.externalRefs: true`.
 
@@ -82,14 +82,12 @@ Each entry in the `externalRefs` list supports:
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `id` | Yes | — | Unique alias for referencing this entry |
-| `kind` | Yes | — | Resource kind: `ConfigMap`, `Secret`, `PersistentVolumeClaim`, or `ExternalName` |
-| `mode` | No | `reference` | `reference` (pre-existing resource) or `create` (chart creates the resource). Only `ExternalName` supports `create`. |
+| `kind` | Yes | — | Resource kind: `ConfigMap`, `Secret`, `PersistentVolumeClaim`, or `Service` |
+| `mode` | No | `reference` | `reference` (pre-existing resource) or `create` (chart creates the resource). Only `Service` supports `create`. |
 | `name` | When mode=reference | — | Actual Kubernetes resource name |
-| `externalName` | When kind=ExternalName, mode=create | — | DNS hostname for the ExternalName service |
-| `fullnameOverride` | No | — | Override the generated ExternalName service name entirely (ExternalName + create only) |
-| `annotations` | No | — | Additional annotations for ExternalName services |
-| `group` | No | `""` | API group (empty string for core resources) |
-| `version` | No | `"v1"` | API version |
+| `externalName` | When kind=Service, mode=create | — | DNS hostname for the rendered `Service.spec.externalName` |
+| `fullnameOverride` | No | — | Override the generated Service name entirely (`kind: Service` + `mode: create` only) |
+| `annotations` | No | — | Additional annotations for created Services |
 | `optional` | No | — | Mark the reference as optional |
 
 ### Mode behavior
@@ -97,8 +95,8 @@ Each entry in the `externalRefs` list supports:
 | Kind | Allowed modes | What happens |
 |------|--------------|--------------|
 | ConfigMap / Secret / PVC | `reference` only | No resource created. `name` is used for lookups. |
-| ExternalName | `create` | Chart creates a `Service/ExternalName`. Name = `fullnameOverride` or `<library.name>-<id>`. |
-| ExternalName | `reference` | No resource created. `name` used for `externalServiceRef` resolution. |
+| Service | `create` | Chart creates a `Service` with `spec.type: ExternalName`. Name = `fullnameOverride` or `<library.name>-<id>`. |
+| Service | `reference` | No resource created. `name` used for `externalServiceRef` resolution. |
 
 ### Registry definition
 
@@ -123,24 +121,24 @@ externalRefs:
     kind: PersistentVolumeClaim
     name: shared-data-pvc
 
-  # ExternalName — chart creates the Service
+  # Service — chart creates a Service with spec.type=ExternalName
   - id: database
-    kind: ExternalName
+    kind: Service
     mode: create
     externalName: db.prod.example.com
 
-  # ExternalName — exact name override
+  # Service — exact name override
   - id: cache
-    kind: ExternalName
+    kind: Service
     mode: create
     externalName: cache.prod.example.com
     fullnameOverride: "redis-cache"
     annotations:
       service.beta.kubernetes.io/description: "External Redis cache"
 
-  # ExternalName — reference a pre-existing service
+  # Service — reference a pre-existing service
   - id: partner-api
-    kind: ExternalName
+    kind: Service
     mode: reference
     name: partner-api-gateway
 ```
@@ -189,7 +187,7 @@ controller:
 
 ### externalServiceRef
 
-For `ExternalName` entries, use `externalServiceRef` in env vars to resolve the Kubernetes service name:
+For `Service` entries, use `externalServiceRef` in env vars to resolve the Kubernetes service name:
 
 - **mode: create** — resolves to `fullnameOverride` or `<library.name>-<id>`
 - **mode: reference** — resolves to `name`

--- a/charts/common/README.md.gotmpl
+++ b/charts/common/README.md.gotmpl
@@ -294,19 +294,16 @@ nameReference:
       - path: spec/values/externalRefs/name
         kind: HelmRelease
         group: helm.toolkit.fluxcd.io
-        version: v2
   - kind: Secret
     fieldSpecs:
       - path: spec/values/externalRefs/name
         kind: HelmRelease
         group: helm.toolkit.fluxcd.io
-        version: v2
   - kind: PersistentVolumeClaim
     fieldSpecs:
       - path: spec/values/externalRefs/name
         kind: HelmRelease
         group: helm.toolkit.fluxcd.io
-        version: v2
 ```
 
 ### Migration from inline refs

--- a/charts/common/README.md.gotmpl
+++ b/charts/common/README.md.gotmpl
@@ -34,6 +34,7 @@ Major Changes to functions are documented with the version affected. **Before up
 |networkpolicy template changes|10.0.0|add possibility to create multiple networkpolicies|https://github.com/bedag/helm-charts/pull/77|
 |ingress template changes|11.0.0|add possibility to create multiple ingress objects|https://github.com/bedag/helm-charts/pull/134
 |ingress template changes|12.0.0|support defining multiple hosts and secrets for one ingress|https://github.com/bedag/helm-charts/pull/138
+|unified externalRefs|12.7.0|List-based externalRefs registry for ConfigMaps, Secrets, PVCs, and ExternalName services. Supports `mode: create` (chart-managed) and `mode: reference` (pre-existing). New `externalServiceRef` env field resolves ExternalName service names.|
 {{/*
   Chart Values
 */}}
@@ -64,3 +65,278 @@ Major Changes to functions are documented with the version affected. **Before up
 | {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
   {{- end }}
 {{- end }}
+
+## externalRefs
+
+The `externalRefs` feature provides a unified registry for declaring external dependencies at the top level of your values. It supports four resource kinds:
+
+- **ConfigMap** / **Secret** / **PersistentVolumeClaim** — reference pre-existing resources by alias in `envFrom`, `volumes`, `env valueFrom`, Ingress TLS, ServiceMonitor basicAuth, and imagePullSecrets
+- **ExternalName** — create or reference Kubernetes `ExternalName` services for external dependencies (databases, caches, APIs), resolvable in env vars via `externalServiceRef`
+
+Enable the feature by setting `includes.externalRefs: true`.
+
+### Fields
+
+Each entry in the `externalRefs` list supports:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `id` | Yes | — | Unique alias for referencing this entry |
+| `kind` | Yes | — | Resource kind: `ConfigMap`, `Secret`, `PersistentVolumeClaim`, or `ExternalName` |
+| `mode` | No | `reference` | `reference` (pre-existing resource) or `create` (chart creates the resource). Only `ExternalName` supports `create`. |
+| `name` | When mode=reference | — | Actual Kubernetes resource name |
+| `externalName` | When kind=ExternalName, mode=create | — | DNS hostname for the ExternalName service |
+| `fullnameOverride` | No | — | Override the generated ExternalName service name entirely (ExternalName + create only) |
+| `annotations` | No | — | Additional annotations for ExternalName services |
+| `group` | No | `""` | API group (empty string for core resources) |
+| `version` | No | `"v1"` | API version |
+| `optional` | No | — | Mark the reference as optional |
+
+### Mode behavior
+
+| Kind | Allowed modes | What happens |
+|------|--------------|--------------|
+| ConfigMap / Secret / PVC | `reference` only | No resource created. `name` is used for lookups. |
+| ExternalName | `create` | Chart creates a `Service/ExternalName`. Name = `fullnameOverride` or `<library.name>-<id>`. |
+| ExternalName | `reference` | No resource created. `name` used for `externalServiceRef` resolution. |
+
+### Registry definition
+
+```yaml
+includes:
+  externalRefs: true
+
+externalRefs:
+  # ConfigMap (reference only)
+  - id: app-config
+    kind: ConfigMap
+    name: my-app-configmap
+
+  # Secret (reference only)
+  - id: app-secrets
+    kind: Secret
+    name: my-app-secrets
+    optional: true
+
+  # PVC (reference only)
+  - id: shared-data
+    kind: PersistentVolumeClaim
+    name: shared-data-pvc
+
+  # ExternalName — chart creates the Service
+  - id: database
+    kind: ExternalName
+    mode: create
+    externalName: db.prod.example.com
+
+  # ExternalName — exact name override
+  - id: cache
+    kind: ExternalName
+    mode: create
+    externalName: cache.prod.example.com
+    fullnameOverride: "redis-cache"
+    annotations:
+      service.beta.kubernetes.io/description: "External Redis cache"
+
+  # ExternalName — reference a pre-existing service
+  - id: partner-api
+    kind: ExternalName
+    mode: reference
+    name: partner-api-gateway
+```
+
+### envFrom (controller-level or container-level)
+
+```yaml
+controller:
+  envFrom:
+    - externalRef: app-config
+    - externalRef: app-secrets
+      optional: false
+```
+
+### volumes
+
+```yaml
+controller:
+  volumes:
+    - name: config-vol
+      externalRef: app-config
+    - name: secret-vol
+      externalRef: app-secrets
+```
+
+### env valueFrom
+
+For list-type `env` entries using `valueFrom.secretKeyRef` or `valueFrom.configMapKeyRef`, use `externalRef` instead of `name` to resolve the resource name from the registry. `secretKeyRef` entries must reference `kind: Secret`, and `configMapKeyRef` must reference `kind: ConfigMap`.
+
+```yaml
+controller:
+  containers:
+    main:
+      env:
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              externalRef: app-secrets
+              key: secret-key
+        - name: CONFIG_VALUE
+          valueFrom:
+            configMapKeyRef:
+              externalRef: app-config
+              key: config-key
+```
+
+### externalServiceRef
+
+For `ExternalName` entries, use `externalServiceRef` in env vars to resolve the Kubernetes service name:
+
+- **mode: create** — resolves to `fullnameOverride` or `<library.name>-<id>`
+- **mode: reference** — resolves to `name`
+
+```yaml
+controller:
+  containers:
+    main:
+      env:
+        - name: DATABASE_HOST
+          externalServiceRef: database
+        - name: PARTNER_API_HOST
+          externalServiceRef: partner-api
+```
+
+### ServiceMonitor basicAuth
+
+When `servicemonitor.basicAuth.enabled` is true, the `existingSecret` field accepts either a plain string or an object with `externalRef` to resolve the secret name. The referenced entry must have `kind: Secret`.
+
+```yaml
+externalRefs:
+  - id: metrics-creds
+    kind: Secret
+    name: my-metrics-credentials
+
+servicemonitor:
+  deploy: true
+  basicAuth:
+    enabled: true
+    existingSecret:
+      externalRef: metrics-creds
+```
+
+### Ingress TLS secretName
+
+The `secretName` field in ingress rules accepts either a plain string or an object with `externalRef`. The referenced entry must have `kind: Secret`.
+
+When `secretName` is an externalRef object, `tls.type` is automatically inferred as `"existing"`.
+
+```yaml
+externalRefs:
+  - id: app-tls
+    kind: Secret
+    name: my-tls-certificate
+
+ingresses:
+  app:
+    deploy: true
+    ingressClassName: nginx
+    rules:
+      - host: app.example.com
+        http:
+          paths:
+            - backend:
+                serviceNameSuffix: my-service
+                servicePort: http
+              path: "/"
+        secretName:
+          externalRef: app-tls
+    tls: {}
+```
+
+### imagePullSecrets
+
+Set `name` to an object with `externalRef` to resolve the pull secret name. The referenced entry must have `kind: Secret`.
+
+```yaml
+externalRefs:
+  - id: registry-creds
+    kind: Secret
+    name: my-registry-credentials
+
+secrets:
+  data:
+    registry:
+      pullSecret:
+        enabled: true
+        name:
+          externalRef: registry-creds
+```
+
+### `optional` precedence
+
+The `optional` field follows this precedence (highest to lowest):
+
+1. **Entry-level**: `optional` set directly on the envFrom/volume entry
+2. **Registry-level**: `optional` set on the externalRefs registry entry
+3. **Omitted**: if neither is set, `optional` is not emitted
+
+### Why a list?
+
+The `externalRefs` registry uses a list (not a map) so that Kustomize `nameReference` transformers can match all entries with a single generic fieldSpec. This is particularly useful with Flux `HelmRelease` resources, where Kustomize can automatically update resource names across all `externalRefs` entries.
+
+Because Kustomize auto-traverses array elements, one `fieldSpecs` path covers every entry regardless of its `id`. A map-based structure would require enumerating each key explicitly, which defeats the purpose.
+
+Example `nameReference` configuration for a Flux `HelmRelease`:
+
+```yaml
+nameReference:
+  - kind: ConfigMap
+    fieldSpecs:
+      - path: spec/values/externalRefs/name
+        kind: HelmRelease
+        group: helm.toolkit.fluxcd.io
+        version: v2
+  - kind: Secret
+    fieldSpecs:
+      - path: spec/values/externalRefs/name
+        kind: HelmRelease
+        group: helm.toolkit.fluxcd.io
+        version: v2
+  - kind: PersistentVolumeClaim
+    fieldSpecs:
+      - path: spec/values/externalRefs/name
+        kind: HelmRelease
+        group: helm.toolkit.fluxcd.io
+        version: v2
+```
+
+### Migration from inline refs
+
+Before (inline):
+
+```yaml
+controller:
+  envFrom:
+    - configMapRef:
+        name: my-app-configmap
+    - secretRef:
+        name: my-app-secrets
+        optional: true
+```
+
+After (alias-based):
+
+```yaml
+externalRefs:
+  - id: app-config
+    kind: ConfigMap
+    name: my-app-configmap
+  - id: app-secrets
+    kind: Secret
+    name: my-app-secrets
+    optional: true
+
+controller:
+  envFrom:
+    - externalRef: app-config
+    - externalRef: app-secrets
+```

--- a/charts/common/ci/values.externalrefs-duplicate-id.test.yaml
+++ b/charts/common/ci/values.externalrefs-duplicate-id.test.yaml
@@ -1,0 +1,15 @@
+includes:
+  externalRefs: true
+
+# Negative regression fixture:
+# Duplicate ids must fail validation even when only the includes.externalRefs render path is enabled.
+externalRefs:
+  - id: duplicate-service
+    kind: Service
+    mode: create
+    externalName: db-one.prod.example.com
+
+  - id: duplicate-service
+    kind: Service
+    mode: create
+    externalName: db-two.prod.example.com

--- a/charts/common/ci/values.externalrefs-invalid-kind.test.yaml
+++ b/charts/common/ci/values.externalrefs-invalid-kind.test.yaml
@@ -1,0 +1,10 @@
+includes:
+  externalRefs: true
+
+# Negative regression fixture:
+# Unknown kinds must be rejected by schema validation.
+externalRefs:
+  - id: invalid-service
+    kind: InvalidKind
+    mode: create
+    externalName: db.prod.example.com

--- a/charts/common/ci/values.test.yaml
+++ b/charts/common/ci/values.test.yaml
@@ -4,6 +4,7 @@ includes:
   deployment: true
   statefulset: true
   service: true
+  ingress: true
   envSecret: true
   envConfigMap: true
   # files is needed for mounted volumes (secrets or configmaps)
@@ -13,10 +14,41 @@ includes:
   pvcs: true
   job: true
   cronjob: true
+  servicemonitor: true
+  externalRefs: true
 
 # start common.ingress
-ingress:
-  deploy: true
+ingresses:
+  ingress-1:
+    deploy: true
+    ingressClassName: nginx
+    rules:
+      - host: myapp.cluster.local
+        http:
+          paths:
+            - backend:
+                serviceNameSuffix: component-1
+                servicePort: http
+              path: "/"
+              pathType: "ImplementationSpecific"
+        secretName:
+          externalRef: app-secrets
+    tls: {}
+  ingress-2:
+    deploy: true
+    ingressClassName: nginx
+    rules:
+      - host: legacy.cluster.local
+        http:
+          paths:
+            - backend:
+                serviceNameSuffix: component-1
+                servicePort: http
+              path: "/"
+              pathType: "ImplementationSpecific"
+        secretName: my-existing-tls-secret
+    tls:
+      type: "existing"
 # end common.ingress
 
 # start common.networkpolicy
@@ -29,7 +61,8 @@ servicemonitor:
   deploy: true
   basicAuth:
     enabled: true
-    existingSecret: ""
+    existingSecret:
+      externalRef: app-secrets
     newSecret:
       username: username
       password: changeit
@@ -44,6 +77,45 @@ servicemonitor:
 pvcs:
   - name: name-of-pvc
 # end common.pvcs
+
+# externalRefs is a unified registry of external dependencies
+externalRefs:
+  - id: app-config
+    kind: ConfigMap
+    name: my-app-config
+  - id: app-secrets
+    kind: Secret
+    name: my-app-secrets
+    optional: true
+  - id: shared-data
+    kind: PersistentVolumeClaim
+    name: shared-data-pvc
+  # ExternalName service — mode: create renders a Service/ExternalName resource
+  - id: ext-database
+    kind: ExternalName
+    mode: create
+    externalName: db.prod.example.com
+  # ExternalName with fullnameOverride and annotations
+  - id: ext-cache
+    kind: ExternalName
+    mode: create
+    externalName: cache.prod.example.com
+    fullnameOverride: "redis-cache"
+    annotations:
+      service.beta.kubernetes.io/description: "External Redis cache"
+  # ExternalName reference — points to an existing service, no resource created
+  - id: partner-api
+    kind: ExternalName
+    mode: reference
+    name: partner-api-gateway
+
+secrets:
+  data:
+    registry:
+      pullSecret:
+        enabled: true
+        name:
+          externalRef: app-secrets
 
 # components are a dictionary of single components to be configured
 components:
@@ -80,6 +152,10 @@ components:
     controller:
       deploy: true
       type: "Deployment"
+      envFrom:
+        - externalRef: app-config
+        - externalRef: app-secrets
+          optional: false
       hostAliases:
       - ip: "127.0.0.1"
         hostnames:
@@ -90,6 +166,14 @@ components:
         - "foo.remote"
         - "bar.remote"
 
+      volumes:
+        - name: config-vol
+          externalRef: app-config
+        - name: secret-vol
+          externalRef: app-secrets
+        - name: data-vol
+          externalRef: shared-data
+
       containers:
         container-1:
           image:
@@ -98,9 +182,35 @@ components:
             - foo
           args:
             - bar
+          envFrom:
+            - externalRef: app-config
+            - configMapRef:
+                name: legacy-configmap
+          volumeMounts:
+            - name: config-vol
+              path: /etc/app-config
+            - name: secret-vol
+              path: /etc/app-secrets
+            - name: data-vol
+              path: /data
           env:
             - name: "foo"
               value: "bar"
+            - name: DATABASE_HOST
+              externalServiceRef: ext-database
+            - name: PARTNER_API_HOST
+              externalServiceRef: partner-api
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  externalRef: app-secrets
+                  key: secret-key
+                  optional: true
+            - name: CONFIG_VALUE
+              valueFrom:
+                configMapKeyRef:
+                  externalRef: app-config
+                  key: config-key
           envConfigMap:
             foo: bar
           resources:
@@ -189,6 +299,9 @@ components:
       deploy: true
       type: "StatefulSet"
 
+      envFrom:
+        - externalRef: app-secrets
+
       extraVolumeClaimTemplates:
         - metadata:
             name: foobar
@@ -216,6 +329,8 @@ components:
           readOnly: true
           volumeAttributes:
             secretProviderClass: "azure-kvname"
+        - name: ext-config-vol
+          externalRef: app-config
 
       hostAliases:
       - ip: "127.0.0.1"

--- a/charts/common/ci/values.test.yaml
+++ b/charts/common/ci/values.test.yaml
@@ -78,7 +78,9 @@ pvcs:
   - name: name-of-pvc
 # end common.pvcs
 
-# externalRefs is a unified registry of external dependencies
+# externalRefs is the happy-path coverage for the unified registry.
+# This fixture should render successfully and exercise both reference-based lookups
+# and chart-managed Services with `spec.type: ExternalName`.
 externalRefs:
   - id: app-config
     kind: ConfigMap
@@ -90,22 +92,22 @@ externalRefs:
   - id: shared-data
     kind: PersistentVolumeClaim
     name: shared-data-pvc
-  # ExternalName service — mode: create renders a Service/ExternalName resource
+  # mode=create should render a Service with `spec.type: ExternalName`
   - id: ext-database
-    kind: ExternalName
+    kind: Service
     mode: create
     externalName: db.prod.example.com
-  # ExternalName with fullnameOverride and annotations
+  # fullnameOverride and annotations should be applied to the rendered Service
   - id: ext-cache
-    kind: ExternalName
+    kind: Service
     mode: create
     externalName: cache.prod.example.com
     fullnameOverride: "redis-cache"
     annotations:
       service.beta.kubernetes.io/description: "External Redis cache"
-  # ExternalName reference — points to an existing service, no resource created
+  # mode=reference should not render a resource and should resolve to this existing Service name
   - id: partner-api
-    kind: ExternalName
+    kind: Service
     mode: reference
     name: partner-api-gateway
 

--- a/charts/common/templates/_container.yaml
+++ b/charts/common/templates/_container.yaml
@@ -19,7 +19,36 @@
       value: {{ default "Europe/Zurich" $root.Values.timezone | quote }}
   {{- with $containerValues.env }}
     {{- if (kindIs "slice" .) }}
-      {{- toYaml . | nindent 4 }}
+      {{- range $entry := . }}
+        {{- if and (hasKey $entry "valueFrom") (hasKey $entry.valueFrom "secretKeyRef") (hasKey $entry.valueFrom.secretKeyRef "externalRef") }}
+        {{- $resolved := include "library.externalRef" (dict "id" $entry.valueFrom.secretKeyRef.externalRef "externalRefs" ($root.Values.externalRefs | default list)) | fromJson }}
+        {{- include "library.externalRef.validateKind" (dict "ref" $resolved "allowedKinds" (list "Secret") "context" "env valueFrom secretKeyRef") }}
+    - name: {{ $entry.name }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ $resolved.name }}
+          key: {{ $entry.valueFrom.secretKeyRef.key }}
+          {{- if hasKey $entry.valueFrom.secretKeyRef "optional" }}
+          optional: {{ $entry.valueFrom.secretKeyRef.optional }}
+          {{- end }}
+        {{- else if and (hasKey $entry "valueFrom") (hasKey $entry.valueFrom "configMapKeyRef") (hasKey $entry.valueFrom.configMapKeyRef "externalRef") }}
+        {{- $resolved := include "library.externalRef" (dict "id" $entry.valueFrom.configMapKeyRef.externalRef "externalRefs" ($root.Values.externalRefs | default list)) | fromJson }}
+        {{- include "library.externalRef.validateKind" (dict "ref" $resolved "allowedKinds" (list "ConfigMap") "context" "env valueFrom configMapKeyRef") }}
+    - name: {{ $entry.name }}
+      valueFrom:
+        configMapKeyRef:
+          name: {{ $resolved.name }}
+          key: {{ $entry.valueFrom.configMapKeyRef.key }}
+          {{- if hasKey $entry.valueFrom.configMapKeyRef "optional" }}
+          optional: {{ $entry.valueFrom.configMapKeyRef.optional }}
+          {{- end }}
+        {{- else if hasKey $entry "externalServiceRef" }}
+    - name: {{ $entry.name }}
+      value: {{ include "library.externalRef.resolveServiceName" (dict "id" $entry.externalServiceRef "externalRefs" ($root.Values.externalRefs | default list) "root" $root "context" (printf "env[%s]" $entry.name)) }}
+        {{- else }}
+      {{- list $entry | toYaml | nindent 4 }}
+        {{- end }}
+      {{- end }}
     {{- else }}
       {{- range $key, $value := . }}
     - name: {{ $key }}
@@ -72,11 +101,51 @@
   {{- end }}
   {{- if or $containerValues.envFrom $controllerValues.envFrom $containerValues.envSecret $containerValues.envConfigMap $controllerValues.envSecret $controllerValues.envConfigMap }}
   envFrom:
-    {{- with $containerValues.envFrom }}
-      {{- toYaml . | nindent 4 }}
+    {{- range $entry := $containerValues.envFrom }}
+    {{- if $entry.externalRef }}
+    {{- if or (hasKey $entry "configMapRef") (hasKey $entry "secretRef") }}
+    {{- fail (printf "envFrom entry has both externalRef '%s' and configMapRef/secretRef — these conflict" $entry.externalRef) }}
     {{- end }}
-    {{- with $controllerValues.envFrom }}
-      {{- toYaml . | nindent 4 }}
+    {{- $resolved := include "library.externalRef" (dict "id" $entry.externalRef "externalRefs" ($root.Values.externalRefs | default list)) | fromJson }}
+    {{- include "library.externalRef.validateKind" (dict "ref" $resolved "allowedKinds" (list "ConfigMap" "Secret") "context" "envFrom") }}
+    {{- if eq $resolved.kind "ConfigMap" }}
+    - configMapRef:
+        name: {{ $resolved.name }}
+    {{- else }}
+    - secretRef:
+        name: {{ $resolved.name }}
+    {{- end }}
+    {{- if hasKey $entry "optional" }}
+        optional: {{ $entry.optional }}
+    {{- else if hasKey $resolved "optional" }}
+        optional: {{ $resolved.optional }}
+    {{- end }}
+    {{- else }}
+    {{- list $entry | toYaml | nindent 4 }}
+    {{- end }}
+    {{- end }}
+    {{- range $entry := $controllerValues.envFrom }}
+    {{- if $entry.externalRef }}
+    {{- if or (hasKey $entry "configMapRef") (hasKey $entry "secretRef") }}
+    {{- fail (printf "envFrom entry has both externalRef '%s' and configMapRef/secretRef — these conflict" $entry.externalRef) }}
+    {{- end }}
+    {{- $resolved := include "library.externalRef" (dict "id" $entry.externalRef "externalRefs" ($root.Values.externalRefs | default list)) | fromJson }}
+    {{- include "library.externalRef.validateKind" (dict "ref" $resolved "allowedKinds" (list "ConfigMap" "Secret") "context" "envFrom") }}
+    {{- if eq $resolved.kind "ConfigMap" }}
+    - configMapRef:
+        name: {{ $resolved.name }}
+    {{- else }}
+    - secretRef:
+        name: {{ $resolved.name }}
+    {{- end }}
+    {{- if hasKey $entry "optional" }}
+        optional: {{ $entry.optional }}
+    {{- else if hasKey $resolved "optional" }}
+        optional: {{ $resolved.optional }}
+    {{- end }}
+    {{- else }}
+    {{- list $entry | toYaml | nindent 4 }}
+    {{- end }}
     {{- end }}
     {{- if $controllerValues.envSecret }}
     - secretRef:

--- a/charts/common/templates/_cronjob.yaml
+++ b/charts/common/templates/_cronjob.yaml
@@ -5,6 +5,9 @@
 {{- if eq $component.controller.type "CronJob" }}
 {{- $cronjob := $component.controller }}
 {{- if $cronjob.deploy }}
+{{- if $root.Values.externalRefs }}
+{{- include "library.externalRefs.validate" (dict "externalRefs" $root.Values.externalRefs "root" $root) }}
+{{- end }}
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/charts/common/templates/_deployment.yaml
+++ b/charts/common/templates/_deployment.yaml
@@ -5,6 +5,9 @@
 {{- if eq $component.controller.type "Deployment" }}
 {{- $deployment := $component.controller }}
 {{- if $deployment.deploy }}
+{{- if $root.Values.externalRefs }}
+{{- include "library.externalRefs.validate" (dict "externalRefs" $root.Values.externalRefs "root" $root) }}
+{{- end }}
 ---
 kind: Deployment
 apiVersion: apps/v1

--- a/charts/common/templates/_externalname-service.yaml
+++ b/charts/common/templates/_externalname-service.yaml
@@ -1,0 +1,21 @@
+{{- define "common.externalNameService" -}}
+{{- $root := . }}
+{{- range $ref := .Values.externalRefs }}
+{{- if and (eq $ref.kind "ExternalName") (eq ($ref.mode | default "reference") "create") }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $ref.fullnameOverride | default (printf "%s-%s" (include "library.name" $root) $ref.id) }}
+  labels:
+{{ include "library.labels.standard" $root | indent 4 }}
+{{- with $ref.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  type: ExternalName
+  externalName: {{ required (printf "externalRefs[id=%s].externalName is required" $ref.id) $ref.externalName }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/common/templates/_externalname-service.yaml
+++ b/charts/common/templates/_externalname-service.yaml
@@ -1,7 +1,7 @@
 {{- define "common.externalNameService" -}}
 {{- $root := . }}
 {{- range $ref := .Values.externalRefs }}
-{{- if and (eq $ref.kind "ExternalName") (eq ($ref.mode | default "reference") "create") }}
+{{- if and (eq $ref.kind "Service") (eq ($ref.mode | default "reference") "create") }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/common/templates/_ingress-ingress.yaml
+++ b/charts/common/templates/_ingress-ingress.yaml
@@ -1,5 +1,8 @@
 {{- define "common.ingress.ingress" -}}
 {{- $root := . }}
+{{- if $root.Values.externalRefs }}
+{{- include "library.externalRefs.validate" (dict "externalRefs" $root.Values.externalRefs "root" $root) }}
+{{- end }}
 {{- $ingresses := .Values.ingresses }}
 {{- range $name, $ingress := $ingresses }}
 {{- if $ingress.deploy }}
@@ -51,15 +54,24 @@ spec:
           {{- end }}
     {{- end }}
   {{- if $ingress.tls }}
-  {{- if and (ne $ingress.tls.type "none") (ne $ingress.tls.type "") }}
+  {{- $effectiveType := $ingress.tls.type | default "" -}}
+  {{- if or (eq $effectiveType "") (eq $effectiveType "none") }}
+  {{- range $ruleIdx, $rule := $ingress.rules }}
+  {{- if and (kindIs "map" $rule.secretName) (hasKey $rule.secretName "externalRef") $rule.secretName.externalRef }}
+  {{- $effectiveType = "existing" }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if and (ne $effectiveType "none") (ne $effectiveType "") }}
   tls:
-    {{- range $ingress.rules }}
+    {{- range $ruleIdx, $rule := $ingress.rules }}
     - hosts:
-        - {{ .host }}
-      {{- if or (eq $ingress.tls.type "self") (eq $ingress.tls.type "provided") }}
-      secretName: {{ regexReplaceAll "\\W+" .host "-" }}
-      {{- else if eq $ingress.tls.type "existing" }}
-      secretName: {{ .secretName }}
+        - {{ $rule.host }}
+      {{- if or (eq $effectiveType "self") (eq $effectiveType "provided") }}
+      secretName: {{ regexReplaceAll "\\W+" $rule.host "-" }}
+      {{- else if eq $effectiveType "existing" }}
+      {{- $result := include "library.externalRef.fromNestedField" (dict "field" "secretName" "path" (printf "ingresses.%s.rules[%d]" $name $ruleIdx) "value" $rule.secretName "externalRefs" $root.Values.externalRefs "allowedKinds" (list "Secret")) | fromJson }}
+      secretName: {{ $result.value }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/common/templates/_job.yaml
+++ b/charts/common/templates/_job.yaml
@@ -5,6 +5,9 @@
 {{- if eq $component.controller.type "Job" }}
 {{- $job := $component.controller }}
 {{- if $job.deploy }}
+{{- if $root.Values.externalRefs }}
+{{- include "library.externalRefs.validate" (dict "externalRefs" $root.Values.externalRefs "root" $root) }}
+{{- end }}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/charts/common/templates/_pod.yaml
+++ b/charts/common/templates/_pod.yaml
@@ -58,7 +58,80 @@ securityContext: {{- omit $controllerValues.podSecurityContext "enabled" | toYam
 {{- end }}
 volumes:
   {{- range $controllerValues.volumes }}
-  {{- if and .name .type }}
+  {{- if .name }}
+  {{- if hasKey . "externalRef" }}
+  {{- if not .externalRef }}
+    {{- fail (printf "volume '%s': 'externalRef' must not be empty — either provide a valid externalRef id or remove the key" .name) }}
+  {{- end }}
+  - name: {{ template "library.name" $root }}-{{ .name }}
+    {{- if .type }}
+      {{- fail (printf "volume '%s': cannot set both 'type' and 'externalRef' — these are conflicting; use one or the other" .name) }}
+    {{- end }}
+    {{- if .existing }}
+      {{- fail (printf "volume '%s': cannot set 'existing' with 'externalRef' — 'existing' is a legacy volume field; remove it when using externalRef" .name) }}
+    {{- end }}
+    {{- if .claimNameSuffix }}
+      {{- fail (printf "volume '%s': cannot set 'claimNameSuffix' with 'externalRef' — 'claimNameSuffix' is a legacy volume field; remove it when using externalRef" .name) }}
+    {{- end }}
+    {{- if .pvcName }}
+      {{- fail (printf "volume '%s': cannot set 'pvcName' with 'externalRef' — 'pvcName' is a legacy volume field; remove it when using externalRef" .name) }}
+    {{- end }}
+    {{- if .driver }}
+      {{- fail (printf "volume '%s': cannot set 'driver' with 'externalRef' — 'driver' is a legacy volume field; remove it when using externalRef" .name) }}
+    {{- end }}
+    {{- if .medium }}
+      {{- fail (printf "volume '%s': cannot set 'medium' with 'externalRef' — 'medium' is a legacy volume field; remove it when using externalRef" .name) }}
+    {{- end }}
+    {{- if .sizeLimit }}
+      {{- fail (printf "volume '%s': cannot set 'sizeLimit' with 'externalRef' — 'sizeLimit' is a legacy volume field; remove it when using externalRef" .name) }}
+    {{- end }}
+    {{- $refJson := include "library.externalRef" (dict "id" .externalRef "externalRefs" ($root.Values.externalRefs | default list) "context" (printf "volume '%s'" .name)) }}
+    {{- $ref := $refJson | fromJson }}
+    {{- include "library.externalRef.validateKind" (dict "ref" $ref "allowedKinds" (list "ConfigMap" "Secret" "PersistentVolumeClaim") "context" (printf "volume '%s'" .name)) }}
+    {{- if eq $ref.kind "Secret" }}
+    secret:
+      secretName: {{ $ref.name }}
+      {{- if hasKey . "optional" }}
+      optional: {{ .optional }}
+      {{- else if hasKey $ref "optional" }}
+      optional: {{ $ref.optional }}
+      {{- end }}
+      {{- if .items }}
+      items:
+      {{- range .items }}
+        - key: {{ .key }}
+          path: {{ .path }}
+      {{- end }}
+      {{- end }}
+      {{- if .defaultMode }}
+      defaultMode: {{ .defaultMode }}
+      {{- end }}
+    {{- else if eq $ref.kind "ConfigMap" }}
+    configMap:
+      name: {{ $ref.name }}
+      {{- if hasKey . "optional" }}
+      optional: {{ .optional }}
+      {{- else if hasKey $ref "optional" }}
+      optional: {{ $ref.optional }}
+      {{- end }}
+      {{- if .items }}
+      items:
+      {{- range .items }}
+        - key: {{ .key }}
+          path: {{ .path }}
+      {{- end }}
+      {{- end }}
+      {{- if .defaultMode }}
+      defaultMode: {{ .defaultMode }}
+      {{- end }}
+    {{- else if eq $ref.kind "PersistentVolumeClaim" }}
+    persistentVolumeClaim:
+      claimName: {{ $ref.name }}
+      {{- if .readOnly }}
+      readOnly: {{ .readOnly }}
+      {{- end }}
+    {{- end }}
+  {{- else if .type }}
   - name: {{ template "library.name" $root }}-{{ .name }}
   {{- if eq .type "secret" }}
     secret:
@@ -143,6 +216,7 @@ volumes:
   {{- end }}
   {{- end }}
   {{- end }}
+  {{- end }}
   {{- if or $controllerValues.containers $controllerValues.initContainers }}
   {{- $containers := merge (dict) ($controllerValues.containers | default dict) ($controllerValues.initContainers | default dict) }}
   {{- range $containerName, $containerValues := $containers }}
@@ -201,7 +275,8 @@ tolerations:
 {{- if $root.Values.secrets.data.registry.pullSecret.enabled }}
 imagePullSecrets:
 {{- if $root.Values.secrets.data.registry.pullSecret.name }}
-  - name: {{ $root.Values.secrets.data.registry.pullSecret.name }}
+  {{- $result := include "library.externalRef.fromNestedField" (dict "field" "name" "path" "secrets.data.registry.pullSecret" "value" $root.Values.secrets.data.registry.pullSecret.name "externalRefs" ($root.Values.externalRefs | default list) "allowedKinds" (list "Secret")) | fromJson }}
+  - name: {{ $result.value }}
 {{- else }}
   - name: {{ template "library.name" $root }}-registry-pull-secret
 {{- end }}

--- a/charts/common/templates/_servicemonitor-servicemonitor.yaml
+++ b/charts/common/templates/_servicemonitor-servicemonitor.yaml
@@ -2,6 +2,9 @@
 {{- $root := . }}
 {{- if .Values.servicemonitor }}
 {{- if .Values.servicemonitor.deploy }}
+{{- if $root.Values.externalRefs }}
+{{- include "library.externalRefs.validate" (dict "externalRefs" $root.Values.externalRefs "root" $root) }}
+{{- end }}
 {{- range .Values.servicemonitor.endpoints }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -27,14 +30,16 @@ spec:
     basicAuth:
       password:
         {{- if $root.Values.servicemonitor.basicAuth.existingSecret }}
-        name: {{ $root.Values.servicemonitor.basicAuth.existingSecret }}
+        {{- $secretResult := include "library.externalRef.fromNestedField" (dict "field" "existingSecret" "path" "servicemonitor.basicAuth" "value" $root.Values.servicemonitor.basicAuth.existingSecret "externalRefs" $root.Values.externalRefs "allowedKinds" (list "Secret")) | fromJson }}
+        name: {{ $secretResult.value }}
         {{- else }}
         name: {{ template "library.name" $root }}-metrics-credentials
         {{- end }}
         key: {{ .overridePasswordKey | default $root.Values.servicemonitor.basicAuth.passwordKey }}
       username:
         {{- if $root.Values.servicemonitor.basicAuth.existingSecret }}
-        name: {{ $root.Values.servicemonitor.basicAuth.existingSecret }}
+        {{- $secretResult := include "library.externalRef.fromNestedField" (dict "field" "existingSecret" "path" "servicemonitor.basicAuth" "value" $root.Values.servicemonitor.basicAuth.existingSecret "externalRefs" $root.Values.externalRefs "allowedKinds" (list "Secret")) | fromJson }}
+        name: {{ $secretResult.value }}
         {{- else }}
         name: {{ template "library.name" $root }}-metrics-credentials
         {{- end }}

--- a/charts/common/templates/_statefulset.yaml
+++ b/charts/common/templates/_statefulset.yaml
@@ -5,6 +5,9 @@
 {{- if eq $component.controller.type "StatefulSet" }}
 {{- $statefulset := $component.controller }}
 {{- if $statefulset.deploy }}
+{{- if $root.Values.externalRefs }}
+{{- include "library.externalRefs.validate" (dict "externalRefs" $root.Values.externalRefs "root" $root) }}
+{{- end }}
 ---
 kind: StatefulSet
 apiVersion: apps/v1

--- a/charts/common/templates/helpers/_externalrefs.tpl
+++ b/charts/common/templates/helpers/_externalrefs.tpl
@@ -2,11 +2,11 @@
 library.externalRefs.validate validates the top-level externalRefs list.
 Context: dict with keys:
   - externalRefs: list of externalRef entries (each a dict with id, kind, name/externalName, mode, optional).
-  - root: the root context (needed for ExternalName service name computation).
+  - root: the root context (needed for Service kind name computation).
 Fails if:
   - Any entry is missing id or kind
   - id is not unique
-  - kind is not one of: ConfigMap, Secret, PersistentVolumeClaim, ExternalName
+  - kind is not one of: ConfigMap, Secret, PersistentVolumeClaim, Service
   - mode is invalid for the given kind
   - Required fields for the mode are missing
 */ -}}
@@ -34,7 +34,7 @@ Fails if:
     {{- if not (hasKey $ref "kind") -}}
       {{- fail (printf "externalRefs[%d] (id=%s): missing required field 'kind'" $idx $ref.id) -}}
     {{- end -}}
-    {{- $allowedKinds := list "ConfigMap" "Secret" "PersistentVolumeClaim" "ExternalName" -}}
+    {{- $allowedKinds := list "ConfigMap" "Secret" "PersistentVolumeClaim" "Service" -}}
     {{- if not (has $ref.kind $allowedKinds) -}}
       {{- fail (printf "externalRefs[%d] (id=%s): kind '%s' is not valid (allowed: %s)" $idx $ref.id $ref.kind (join ", " $allowedKinds)) -}}
     {{- end -}}
@@ -45,8 +45,8 @@ Fails if:
       {{- fail (printf "externalRefs[%d] (id=%s): mode '%s' is not valid (allowed: create, reference)" $idx $ref.id $mode) -}}
     {{- end -}}
     {{- /* ConfigMap/Secret/PVC only support reference mode */ -}}
-    {{- if and (ne $ref.kind "ExternalName") (eq $mode "create") -}}
-      {{- fail (printf "externalRefs[%d] (id=%s): mode 'create' is only valid for kind 'ExternalName' (got kind '%s')" $idx $ref.id $ref.kind) -}}
+    {{- if and (ne $ref.kind "Service") (eq $mode "create") -}}
+      {{- fail (printf "externalRefs[%d] (id=%s): mode 'create' is only valid for kind 'Service' (got kind '%s')" $idx $ref.id $ref.kind) -}}
     {{- end -}}
     {{- /* Validate required fields based on mode */ -}}
     {{- if eq $mode "reference" -}}
@@ -65,8 +65,8 @@ Fails if:
         {{- fail (printf "externalRefs[%d] (id=%s): 'externalName' must not be empty for mode 'create'" $idx $ref.id) -}}
       {{- end -}}
     {{- end -}}
-    {{- /* Default group and version for non-ExternalName kinds */ -}}
-    {{- if ne $ref.kind "ExternalName" -}}
+    {{- /* Default group and version for non-Service kinds */ -}}
+    {{- if ne $ref.kind "Service" -}}
       {{- if not (hasKey $ref "group") -}}
         {{- $_ := set $ref "group" "" -}}
       {{- end -}}
@@ -164,7 +164,7 @@ Fails if value is empty, wrong type, or externalRef is invalid.
 {{- end -}}
 
 {{- /*
-library.externalRef.resolveServiceName resolves the Kubernetes service name for an ExternalName ref.
+library.externalRef.resolveServiceName resolves the Kubernetes service name for a Service ref.
 Context: dict with keys:
   - id: string (the externalRefs entry id)
   - externalRefs: list (the externalRefs registry)
@@ -172,7 +172,7 @@ Context: dict with keys:
   - context: string (optional, error context)
 For mode=create: returns fullnameOverride or <library.name>-<id>
 For mode=reference: returns name field
-Fails if ref is not kind ExternalName.
+Fails if ref is not kind Service.
 */ -}}
 {{- define "library.externalRef.resolveServiceName" -}}
   {{- $id := .id -}}
@@ -180,8 +180,8 @@ Fails if ref is not kind ExternalName.
   {{- $root := .root -}}
   {{- $context := .context | default "" -}}
   {{- $resolved := include "library.externalRef" (dict "id" $id "externalRefs" $refs "context" $context) | fromJson -}}
-  {{- if ne $resolved.kind "ExternalName" -}}
-    {{- fail (printf "%sexternalServiceRef '%s' has kind '%s' — only 'ExternalName' refs can be resolved as service names" (ternary (printf "%s: " $context) "" (ne $context "")) $id $resolved.kind) -}}
+  {{- if ne $resolved.kind "Service" -}}
+    {{- fail (printf "%sexternalServiceRef '%s' has kind '%s' — only 'Service' refs can be resolved as service names" (ternary (printf "%s: " $context) "" (ne $context "")) $id $resolved.kind) -}}
   {{- end -}}
   {{- $mode := $resolved.mode | default "reference" -}}
   {{- if eq $mode "create" -}}

--- a/charts/common/templates/helpers/_externalrefs.tpl
+++ b/charts/common/templates/helpers/_externalrefs.tpl
@@ -1,0 +1,192 @@
+{{- /*
+library.externalRefs.validate validates the top-level externalRefs list.
+Context: dict with keys:
+  - externalRefs: list of externalRef entries (each a dict with id, kind, name/externalName, mode, optional).
+  - root: the root context (needed for ExternalName service name computation).
+Fails if:
+  - Any entry is missing id or kind
+  - id is not unique
+  - kind is not one of: ConfigMap, Secret, PersistentVolumeClaim, ExternalName
+  - mode is invalid for the given kind
+  - Required fields for the mode are missing
+*/ -}}
+{{- define "library.externalRefs.validate" -}}
+  {{- $refs := .externalRefs | default list -}}
+  {{- $root := .root -}}
+  {{- $seenIds := dict -}}
+  {{- range $idx, $ref := $refs -}}
+    {{- if not (kindIs "map" $ref) -}}
+      {{- fail (printf "externalRefs[%d]: each entry must be an object (got type: %s)" $idx (kindOf $ref)) -}}
+    {{- end -}}
+    {{- /* Require id */ -}}
+    {{- if not (hasKey $ref "id") -}}
+      {{- fail (printf "externalRefs[%d]: missing required field 'id'" $idx) -}}
+    {{- end -}}
+    {{- if not $ref.id -}}
+      {{- fail (printf "externalRefs[%d]: 'id' must not be empty" $idx) -}}
+    {{- end -}}
+    {{- /* Enforce unique id */ -}}
+    {{- if hasKey $seenIds $ref.id -}}
+      {{- fail (printf "externalRefs[%d]: duplicate id '%s' (first defined at index %v)" $idx $ref.id (get $seenIds $ref.id)) -}}
+    {{- end -}}
+    {{- $_ := set $seenIds $ref.id $idx -}}
+    {{- /* Require kind */ -}}
+    {{- if not (hasKey $ref "kind") -}}
+      {{- fail (printf "externalRefs[%d] (id=%s): missing required field 'kind'" $idx $ref.id) -}}
+    {{- end -}}
+    {{- $allowedKinds := list "ConfigMap" "Secret" "PersistentVolumeClaim" "ExternalName" -}}
+    {{- if not (has $ref.kind $allowedKinds) -}}
+      {{- fail (printf "externalRefs[%d] (id=%s): kind '%s' is not valid (allowed: %s)" $idx $ref.id $ref.kind (join ", " $allowedKinds)) -}}
+    {{- end -}}
+    {{- /* Determine mode: default is "reference" */ -}}
+    {{- $mode := $ref.mode | default "reference" -}}
+    {{- $allowedModes := list "create" "reference" -}}
+    {{- if not (has $mode $allowedModes) -}}
+      {{- fail (printf "externalRefs[%d] (id=%s): mode '%s' is not valid (allowed: create, reference)" $idx $ref.id $mode) -}}
+    {{- end -}}
+    {{- /* ConfigMap/Secret/PVC only support reference mode */ -}}
+    {{- if and (ne $ref.kind "ExternalName") (eq $mode "create") -}}
+      {{- fail (printf "externalRefs[%d] (id=%s): mode 'create' is only valid for kind 'ExternalName' (got kind '%s')" $idx $ref.id $ref.kind) -}}
+    {{- end -}}
+    {{- /* Validate required fields based on mode */ -}}
+    {{- if eq $mode "reference" -}}
+      {{- if not (hasKey $ref "name") -}}
+        {{- fail (printf "externalRefs[%d] (id=%s): missing required field 'name' for mode 'reference'" $idx $ref.id) -}}
+      {{- end -}}
+      {{- if not $ref.name -}}
+        {{- fail (printf "externalRefs[%d] (id=%s): 'name' must not be empty for mode 'reference'" $idx $ref.id) -}}
+      {{- end -}}
+    {{- else if eq $mode "create" -}}
+      {{- /* mode=create requires externalName */ -}}
+      {{- if not (hasKey $ref "externalName") -}}
+        {{- fail (printf "externalRefs[%d] (id=%s): missing required field 'externalName' for mode 'create'" $idx $ref.id) -}}
+      {{- end -}}
+      {{- if not $ref.externalName -}}
+        {{- fail (printf "externalRefs[%d] (id=%s): 'externalName' must not be empty for mode 'create'" $idx $ref.id) -}}
+      {{- end -}}
+    {{- end -}}
+    {{- /* Default group and version for non-ExternalName kinds */ -}}
+    {{- if ne $ref.kind "ExternalName" -}}
+      {{- if not (hasKey $ref "group") -}}
+        {{- $_ := set $ref "group" "" -}}
+      {{- end -}}
+      {{- if not (hasKey $ref "version") -}}
+        {{- $_ := set $ref "version" "v1" -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /*
+library.externalRef looks up an externalRef entry by id from the list.
+Context: dict with keys:
+  - id: string (the id to look up)
+  - externalRefs: list (the externalRefs registry)
+  - context: string (optional, describes where the lookup is used for error messages)
+Returns: the matching entry dict (which already contains the id field).
+Fails if id is not found in the registry.
+*/ -}}
+{{- define "library.externalRef" -}}
+  {{- $id := .id -}}
+  {{- $refs := .externalRefs | default list -}}
+  {{- $context := .context | default "" -}}
+  {{- $found := dict -}}
+  {{- range $ref := $refs -}}
+    {{- if eq ($ref.id | default "") $id -}}
+      {{- $_ := set $found "ref" $ref -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not (hasKey $found "ref") -}}
+    {{- if $context -}}
+      {{- fail (printf "%s: externalRef '%s' not found in externalRefs registry" $context $id) -}}
+    {{- else -}}
+      {{- fail (printf "externalRef '%s' not found in externalRefs registry" $id) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- get $found "ref" | toJson -}}
+{{- end -}}
+
+{{- /*
+library.externalRef.validateKind validates that a ref's kind is allowed in a given context.
+Context: dict with keys:
+  - ref: dict (the externalRef entry with id, kind, name, optional)
+  - allowedKinds: list of allowed kind strings
+  - context: string describing the usage context (e.g. "envFrom", "volumes")
+Fails if ref.kind is not in allowedKinds.
+*/ -}}
+{{- define "library.externalRef.validateKind" -}}
+  {{- $ref := .ref -}}
+  {{- $allowedKinds := .allowedKinds -}}
+  {{- $context := .context -}}
+  {{- if not (has $ref.kind $allowedKinds) -}}
+    {{- fail (printf "externalRef '%s' has kind '%s' which is not valid in %s context (allowed: %s)" $ref.id $ref.kind $context (join ", " $allowedKinds)) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /*
+library.externalRef.fromNestedField validates and resolves a field that can be either a
+plain string or an object with an externalRef key.
+Context: dict with keys:
+  - field: string (field name, e.g. "secretName")
+  - path: string (path context, e.g. "ingresses.ingress-1.rules[0]")
+  - value: the field value (string or map)
+  - externalRefs: list (the externalRefs registry)
+  - allowedKinds: list of allowed kind strings
+Returns JSON:
+  - String case: {"value": "the-string", "isRef": false}
+  - ExternalRef case: {"value": "<resolved-name>", "isRef": true, "ref": <full-ref-object>}
+Fails if value is empty, wrong type, or externalRef is invalid.
+*/ -}}
+{{- define "library.externalRef.fromNestedField" -}}
+  {{- $field := .field -}}
+  {{- $path := .path -}}
+  {{- $value := .value -}}
+  {{- $externalRefs := .externalRefs | default list -}}
+  {{- $allowedKinds := .allowedKinds -}}
+  {{- if kindIs "map" $value -}}
+    {{- if not (hasKey $value "externalRef") -}}
+      {{- fail (printf "%s.%s: object must have an 'externalRef' key (got keys: %s)" $path $field (keys $value | sortAlpha | join ", ")) -}}
+    {{- end -}}
+    {{- if not $value.externalRef -}}
+      {{- fail (printf "%s.%s.externalRef: must not be empty" $path $field) -}}
+    {{- end -}}
+    {{- $resolved := include "library.externalRef" (dict "id" $value.externalRef "externalRefs" $externalRefs "context" (printf "%s.%s" $path $field)) | fromJson -}}
+    {{- include "library.externalRef.validateKind" (dict "ref" $resolved "allowedKinds" $allowedKinds "context" (printf "%s.%s" $path $field)) -}}
+    {{- dict "value" $resolved.name "isRef" true "ref" $resolved | toJson -}}
+  {{- else if kindIs "string" $value -}}
+    {{- if not $value -}}
+      {{- fail (printf "%s.%s: must not be empty" $path $field) -}}
+    {{- end -}}
+    {{- dict "value" $value "isRef" false | toJson -}}
+  {{- else -}}
+    {{- fail (printf "%s.%s: must be a string or an object with 'externalRef' key (got type: %s)" $path $field (kindOf $value)) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /*
+library.externalRef.resolveServiceName resolves the Kubernetes service name for an ExternalName ref.
+Context: dict with keys:
+  - id: string (the externalRefs entry id)
+  - externalRefs: list (the externalRefs registry)
+  - root: the root context (for library.name)
+  - context: string (optional, error context)
+For mode=create: returns fullnameOverride or <library.name>-<id>
+For mode=reference: returns name field
+Fails if ref is not kind ExternalName.
+*/ -}}
+{{- define "library.externalRef.resolveServiceName" -}}
+  {{- $id := .id -}}
+  {{- $refs := .externalRefs | default list -}}
+  {{- $root := .root -}}
+  {{- $context := .context | default "" -}}
+  {{- $resolved := include "library.externalRef" (dict "id" $id "externalRefs" $refs "context" $context) | fromJson -}}
+  {{- if ne $resolved.kind "ExternalName" -}}
+    {{- fail (printf "%sexternalServiceRef '%s' has kind '%s' — only 'ExternalName' refs can be resolved as service names" (ternary (printf "%s: " $context) "" (ne $context "")) $id $resolved.kind) -}}
+  {{- end -}}
+  {{- $mode := $resolved.mode | default "reference" -}}
+  {{- if eq $mode "create" -}}
+    {{- $resolved.fullnameOverride | default (printf "%s-%s" (include "library.name" $root) $id) -}}
+  {{- else -}}
+    {{- $resolved.name -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/common/templates/includes.yaml
+++ b/charts/common/templates/includes.yaml
@@ -7,6 +7,10 @@
   {{- template "common.service" . }}
 {{- end -}}
 
+{{- if .Values.includes.externalRefs }}
+  {{- template "common.externalNameService" . }}
+{{- end -}}
+
 {{- if .Values.includes.statefulset }}
   {{- template "common.statefulset" . }}
 {{- end -}}

--- a/charts/common/templates/includes.yaml
+++ b/charts/common/templates/includes.yaml
@@ -8,6 +8,7 @@
 {{- end -}}
 
 {{- if .Values.includes.externalRefs }}
+  {{- include "library.externalRefs.validate" (dict "externalRefs" (.Values.externalRefs | default list) "root" .) -}}
   {{- template "common.externalNameService" . }}
 {{- end -}}
 

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -82,13 +82,88 @@
           }
         },
         "env": {
-          "type": ["array", "object"]
+          "oneOf": [
+            {
+              "title": "Environment variables as array",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 },
+                  "value": { "type": "string" },
+                  "externalServiceRef": {
+                    "type": "string",
+                    "description": "Reference to an ExternalName entry in externalRefs — resolves to the service name"
+                  },
+                  "valueFrom": {
+                    "type": "object",
+                    "properties": {
+                      "secretKeyRef": {
+                        "type": "object",
+                        "properties": {
+                          "name": { "type": "string" },
+                          "externalRef": { "type": "string" },
+                          "key": { "type": "string", "minLength": 1 },
+                          "optional": { "type": "boolean" }
+                        },
+                        "required": ["key"]
+                      },
+                      "configMapKeyRef": {
+                        "type": "object",
+                        "properties": {
+                          "name": { "type": "string" },
+                          "externalRef": { "type": "string" },
+                          "key": { "type": "string", "minLength": 1 },
+                          "optional": { "type": "boolean" }
+                        },
+                        "required": ["key"]
+                      },
+                      "fieldRef": {
+                        "type": "object",
+                        "properties": {
+                          "fieldPath": { "type": "string" }
+                        }
+                      },
+                      "resourceFieldRef": {
+                        "type": "object",
+                        "properties": {
+                          "resource": { "type": "string" },
+                          "containerName": { "type": "string" },
+                          "divisor": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "title": "Environment variables as map",
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          ]
         },
         "envSecret": {
           "type": "object"
         },
         "envFrom": {
-          "type": ["array"]
+          "type": ["array"],
+          "items": {
+            "type": "object",
+            "properties": {
+              "secretRef": {
+                "type": "object"
+              },
+              "configMapRef": {
+                "type": "object"
+              },
+              "externalRef": {
+                "type": "string"
+              }
+            }
+          }
         },
         "envConfigMap": {
           "type": "object"
@@ -456,6 +531,10 @@
         "networkpolicy": {
           "type": "boolean",
           "default": false
+        },
+        "externalRefs": {
+          "type": "boolean",
+          "default": false
         }
       }
     },
@@ -485,7 +564,18 @@
                       "default": false
                     },
                     "name": {
-                      "type": "string"
+                      "oneOf": [
+                        { "title": "Existing secret name", "type": "string" },
+                        {
+                          "title": "externalRefs reference",
+                          "type": "object",
+                          "properties": {
+                            "externalRef": { "type": "string", "minLength": 1 }
+                          },
+                          "required": ["externalRef"],
+                          "additionalProperties": false
+                        }
+                      ]
                     }
                   }
                 }
@@ -622,7 +712,18 @@
                     }
                   },
                   "secretName": {
-                    "type": "string"
+                    "oneOf": [
+                      { "title": "Existing secret name", "type": "string" },
+                      {
+                        "title": "externalRefs reference",
+                        "type": "object",
+                        "properties": {
+                          "externalRef": { "type": "string", "minLength": 1 }
+                        },
+                        "required": ["externalRef"],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               }
@@ -632,9 +733,6 @@
             },
             "tls": {
               "type": "object",
-              "required": [
-                "type"
-              ],
               "properties": {
                 "type": {
                   "type": "string",
@@ -743,7 +841,18 @@
               "default": false
             },
             "existingSecret": {
-              "type": "string"
+              "oneOf": [
+                { "title": "Existing secret name", "type": "string" },
+                {
+                  "title": "externalRefs reference",
+                  "type": "object",
+                  "properties": {
+                    "externalRef": { "type": "string", "minLength": 1 }
+                  },
+                  "required": ["externalRef"],
+                  "additionalProperties": false
+                }
+              ]
             },
             "newSecret": {
               "type": "object"
@@ -800,6 +909,94 @@
         },
         "required": [
           "name"
+        ]
+      }
+    },
+    "externalRefs": {
+      "type": "array",
+      "description": "Unified registry of external dependencies — ConfigMaps, Secrets, PVCs, and ExternalName services",
+      "items": {
+        "type": "object",
+        "required": ["id", "kind"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Unique alias for this external reference"
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["ConfigMap", "Secret", "PersistentVolumeClaim", "ExternalName"]
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["create", "reference"],
+            "default": "reference"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Actual Kubernetes resource name (required for mode: reference)"
+          },
+          "externalName": {
+            "type": "string",
+            "minLength": 1,
+            "description": "DNS hostname (required for ExternalName kind with mode: create)"
+          },
+          "fullnameOverride": {
+            "type": "string",
+            "description": "Override the generated service name entirely (ExternalName kind only)"
+          },
+          "annotations": {
+            "type": "object",
+            "description": "Additional annotations (ExternalName kind with mode: create only)",
+            "additionalProperties": { "type": "string" }
+          },
+          "group": {
+            "type": "string",
+            "default": ""
+          },
+          "version": {
+            "type": "string",
+            "default": "v1"
+          },
+          "optional": {
+            "type": "boolean"
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "mode": { "const": "create" }
+              },
+              "required": ["mode"]
+            },
+            "then": {
+              "required": ["id", "kind", "externalName"],
+              "properties": {
+                "kind": { "const": "ExternalName" }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "mode": { "const": "reference" }
+              }
+            },
+            "then": {
+              "required": ["id", "kind", "name"]
+            }
+          },
+          {
+            "if": {
+              "not": { "required": ["mode"] }
+            },
+            "then": {
+              "required": ["id", "kind", "name"]
+            }
+          }
         ]
       }
     },
@@ -890,7 +1087,21 @@
                   "type": "object"
                 },
                 "envFrom": {
-                  "type": ["array"]
+                  "type": ["array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "secretRef": {
+                        "type": "object"
+                      },
+                      "configMapRef": {
+                        "type": "object"
+                      },
+                      "externalRef": {
+                        "type": "string"
+                      }
+                    }
+                  }
                 },
                 "replicas": {
                   "type": "integer",
@@ -1121,12 +1332,24 @@
                             "type": "string"
                           }
                         }
+                      },
+                      "externalRef": {
+                        "type": "string"
                       }
                     },
                     "required": [
-                      "name",
-                      "type"
-                    ]
+                      "name"
+                    ],
+                    "if": {
+                      "not": {
+                        "required": ["externalRef"]
+                      }
+                    },
+                    "then": {
+                      "required": [
+                        "type"
+                      ]
+                    }
                   }
                 },
                 "hostAliases": {

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -94,7 +94,7 @@
                   "value": { "type": "string" },
                   "externalServiceRef": {
                     "type": "string",
-                    "description": "Reference to an ExternalName entry in externalRefs — resolves to the service name"
+                    "description": "Reference to a Service entry in externalRefs — resolves to the service name"
                   },
                   "valueFrom": {
                     "type": "object",
@@ -914,7 +914,7 @@
     },
     "externalRefs": {
       "type": "array",
-      "description": "Unified registry of external dependencies — ConfigMaps, Secrets, PVCs, and ExternalName services",
+      "description": "Unified registry of external dependencies — ConfigMaps, Secrets, PVCs, and Services",
       "items": {
         "type": "object",
         "required": ["id", "kind"],
@@ -926,7 +926,7 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["ConfigMap", "Secret", "PersistentVolumeClaim", "ExternalName"]
+            "enum": ["ConfigMap", "Secret", "PersistentVolumeClaim", "Service"]
           },
           "mode": {
             "type": "string",
@@ -941,15 +941,15 @@
           "externalName": {
             "type": "string",
             "minLength": 1,
-            "description": "DNS hostname (required for ExternalName kind with mode: create)"
+            "description": "DNS hostname (required for Service kind with mode: create)"
           },
           "fullnameOverride": {
             "type": "string",
-            "description": "Override the generated service name entirely (ExternalName kind only)"
+            "description": "Override the generated service name entirely (Service kind only)"
           },
           "annotations": {
             "type": "object",
-            "description": "Additional annotations (ExternalName kind with mode: create only)",
+            "description": "Additional annotations (Service kind with mode: create only)",
             "additionalProperties": { "type": "string" }
           },
           "group": {
@@ -975,7 +975,7 @@
             "then": {
               "required": ["id", "kind", "externalName"],
               "properties": {
-                "kind": { "const": "ExternalName" }
+                "kind": { "const": "Service" }
               }
             }
           },

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -31,6 +31,7 @@ includes:
   # files is needed for mounted volumes (secrets or configmaps)
   files: false
   pvcs: false
+  externalRefs: false
   servicemonitor: false
   networkpolicy: false
 
@@ -46,7 +47,9 @@ secrets:
         # enabled activates the imagePullSecrets in the pod spec
         enabled: false
         # name is optional to override the default name, if omitted uses '{{ template "library.name" $root }}-registry-pull-secret'
-        # name: example-foo
+        # Can be a plain string or an object with externalRef to resolve from the externalRefs registry.
+        # Example: name: "my-pull-secret" OR name: { externalRef: "registry-creds" }
+        # name: ""
 
 # start common.networkpolicy
 # -- networkpolicy restricts all access between the pods. To configure allowed connections, go to components.*.networkpolicy.podSelector
@@ -91,7 +94,9 @@ ingresses:
               path: "/"
               # -- pathType Each path in an Ingress is required to have a corresponding path type. Comment out for using default ("ImplementationSpecific")
               pathType: "ImplementationSpecific"
-        # -- name of existing secrets with tls.crt & tls.key content
+        # -- secretName: name of existing secrets with tls.crt & tls.key content.
+        # Can be a plain string or an object with externalRef to resolve from the externalRefs registry.
+        # Example: secretName: "my-tls-secret" OR secretName: { externalRef: "app-tls" }
         secretName: ""
     # END ONLY FOR MULTI-SERVICE INGRESSES AND/OR SPECIFIC RULES
 
@@ -105,7 +110,8 @@ ingresses:
     tls:
       # -- define your type of tls certificate, it can be one of:
       # none: tls will be disabled
-      # existing: use an existing secret already present in the namespace. Requires `secretName` to be specified in `.rules.host`
+      # existing: use an existing secret already present in the namespace. Requires `secretName` to be specified in `.rules.host`.
+      #   Auto-inferred when `secretName` is an externalRef object (e.g., `secretName: { externalRef: "app-tls" }`).
       # provided: use an officially generated certificate/key
       # k8s: use the default k8s-ingress tls. no further configuration needed
       # self: generate a self signed certificate, which is stored as secret. Needs commonName and validityDuration at least
@@ -142,7 +148,9 @@ servicemonitor:
   basicAuth:
     # -- enabled when set to 'true', adds basic authentication to all endpoints
     enabled: false
-    # -- existingSecret if not empty (""), points to an existing secret (matching name of the resource)
+    # -- existingSecret: points to an existing secret (matching name of the resource).
+    # Can be a plain string or an object with externalRef to resolve from the externalRefs registry.
+    # Example: existingSecret: "my-secret" OR existingSecret: { externalRef: "metrics-creds" }
     existingSecret: ""
     # -- newSecret is a dictionary for defining key/value pairs to be stored in a new secret (See `values.yaml`)
     newSecret: {}
@@ -211,6 +219,54 @@ pvcs:
     # -- storageClassName is optional with a default value of ""
 #   storageClassName: "nfs-data"
 # end common.pvcs
+
+## -- (list) Unified registry of external dependencies — ConfigMaps, Secrets, PVCs, and ExternalName services.
+## Each entry has an `id` alias used for referencing (in envFrom, volumes, env externalServiceRef, etc.).
+## Supported kinds: ConfigMap, Secret, PersistentVolumeClaim, ExternalName.
+## Mode determines behavior:
+##   reference (default) — points to an existing resource, no Kubernetes object is created.
+##   create              — creates a Kubernetes resource (only valid for ExternalName kind).
+## @default -- `[]`
+# externalRefs:
+#   # Reference an existing ConfigMap
+#   - id: my-config
+#     kind: ConfigMap
+#     name: actual-configmap-name    # Actual Kubernetes resource name
+#     optional: true                 # Optional: mark the reference as optional
+#
+#   # Reference an existing Secret
+#   - id: my-secret
+#     kind: Secret
+#     name: actual-secret-name
+#
+#   # Reference an existing PVC
+#   - id: my-pvc
+#     kind: PersistentVolumeClaim
+#     name: actual-pvc-name
+#
+#   # Create an ExternalName service (requires includes.externalRefs: true)
+#   - id: database
+#     kind: ExternalName
+#     mode: create
+#     externalName: db.prod.example.com
+#     # fullnameOverride: "my-db"       # Optional: exact service name (default: <library.name>-database)
+#     # annotations:                     # Optional: additional annotations
+#     #   service.beta.kubernetes.io/description: "External database"
+#
+#   # Reference an existing ExternalName service (no resource created)
+#   - id: partner-api
+#     kind: ExternalName
+#     mode: reference
+#     name: partner-api-gateway         # Actual service name in the cluster
+
+## Usage examples:
+## envFrom with externalRef:
+##   envFrom:
+##     - externalRef: my-config
+## env with externalServiceRef (resolves to ExternalName service name):
+##   env:
+##     - name: DATABASE_HOST
+##       externalServiceRef: database
 
 # components are a dictionary of single components to be configured
 components:
@@ -335,6 +391,7 @@ components:
       #     name: my-secret
       # - configMapRef:
       #     name: my-configmap
+      # - externalRef: my-config   # Reference an externalRefs entry by id
 
       # gatherMetrics is true: service get a label which triggers serviceMonitor to gather metrics
       gatherMetrics: false
@@ -513,6 +570,10 @@ components:
       #    volumeAttributes:
       #      foo: "bar"
       #   END ONLY FOR CSI
+      #   START ONLY FOR EXTERNALREF
+      # - name: config-vol
+      #   externalRef: my-config   # Reference an externalRefs entry by id (replaces type + existing)
+      #   END ONLY FOR EXTERNALREF
       # end pod
 
       # hostAliases defines host names for IP addresses
@@ -570,6 +631,18 @@ components:
           #  - name: foo
           #    value: bar
           #
+          # You can reference external secrets/configmaps via externalRef in valueFrom:
+          #  - name: SECRET_KEY
+          #    valueFrom:
+          #      secretKeyRef:
+          #        externalRef: my-secret-ref   # References an externalRefs entry by id (kind must be Secret)
+          #        key: secret-key
+          #  - name: CONFIG_VALUE
+          #    valueFrom:
+          #      configMapKeyRef:
+          #        externalRef: my-config-ref   # References an externalRefs entry by id (kind must be ConfigMap)
+          #        key: config-key
+          #
           # You can define environment variables as map
           #  foo: bar
 
@@ -585,6 +658,7 @@ components:
           #     name: my-secret
           # - configMapRef:
           #     name: my-configmap
+          # - externalRef: my-config   # Reference an externalRefs entry by id
 
           # configFilesDefaultMode sets permissions for all configFiles mounted.
           # See  'pod.spec.volumes.configMap.defaultMode' or 'pod.spec.volumes.secret.defaultMode' for more information

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -220,12 +220,12 @@ pvcs:
 #   storageClassName: "nfs-data"
 # end common.pvcs
 
-## -- (list) Unified registry of external dependencies — ConfigMaps, Secrets, PVCs, and ExternalName services.
+## -- (list) Unified registry of external dependencies — ConfigMaps, Secrets, PVCs, and Services.
 ## Each entry has an `id` alias used for referencing (in envFrom, volumes, env externalServiceRef, etc.).
-## Supported kinds: ConfigMap, Secret, PersistentVolumeClaim, ExternalName.
+## Supported kinds: ConfigMap, Secret, PersistentVolumeClaim, Service.
 ## Mode determines behavior:
 ##   reference (default) — points to an existing resource, no Kubernetes object is created.
-##   create              — creates a Kubernetes resource (only valid for ExternalName kind).
+##   create              — creates a Kubernetes resource (only valid for Service kind).
 ## @default -- `[]`
 # externalRefs:
 #   # Reference an existing ConfigMap
@@ -244,18 +244,18 @@ pvcs:
 #     kind: PersistentVolumeClaim
 #     name: actual-pvc-name
 #
-#   # Create an ExternalName service (requires includes.externalRefs: true)
+#   # Create a Service with spec.type=ExternalName (requires includes.externalRefs: true)
 #   - id: database
-#     kind: ExternalName
+#     kind: Service
 #     mode: create
 #     externalName: db.prod.example.com
 #     # fullnameOverride: "my-db"       # Optional: exact service name (default: <library.name>-database)
 #     # annotations:                     # Optional: additional annotations
 #     #   service.beta.kubernetes.io/description: "External database"
 #
-#   # Reference an existing ExternalName service (no resource created)
+#   # Reference an existing Service that acts as the external endpoint (no resource created)
 #   - id: partner-api
-#     kind: ExternalName
+#     kind: Service
 #     mode: reference
 #     name: partner-api-gateway         # Actual service name in the cluster
 
@@ -263,7 +263,7 @@ pvcs:
 ## envFrom with externalRef:
 ##   envFrom:
 ##     - externalRef: my-config
-## env with externalServiceRef (resolves to ExternalName service name):
+## env with externalServiceRef (resolves to Service name):
 ##   env:
 ##     - name: DATABASE_HOST
 ##       externalServiceRef: database


### PR DESCRIPTION
## Summary

- Introduces `externalRefs`, a shared registry for external dependencies that can be referenced by ID from multiple parts of the chart
- Supports `ConfigMap`, `Secret`, `PersistentVolumeClaim`, and `Service` entries in the same registry
- Adds support for both creating a `Service` with `spec.type: ExternalName` from chart values and referencing an already existing `Service`
- Adds `externalServiceRef` so container env vars can resolve an external service through `externalRefs`
- Keeps `externalRefs` as an array so Flux/Kustomize `nameReference` rules stay simple

## Why

Today, charts often need to refer to external resources from several different places, for example:

- a `Secret` used in `envFrom`
- a `ConfigMap` used in `valueFrom`
- a `PersistentVolumeClaim` mounted as a volume
- an external hostname that should be exposed through a Kubernetes `Service` with `spec.type: ExternalName`

Without a shared registry, the same resource names need to be repeated at each usage site. That makes values harder to read, increases the risk of drift when names change, and makes GitOps overlays more verbose.

This PR introduces `externalRefs` as a single place to declare those dependencies once and then reference them by ID from supported chart fields.

The same mechanism also supports external services through `kind: Service`, so the chart can either create a `Service` with `spec.type: ExternalName` or point at an already existing `Service`.

## What is `externalRefs`

`externalRefs` is a top-level array in `values.yaml`.

Each entry:

- declares one external dependency
- assigns it a stable `id`
- describes its type via `kind`
- provides the resource name or service configuration needed to use it elsewhere in the chart

Supported kinds in this PR:

- `ConfigMap`
- `Secret`
- `PersistentVolumeClaim`
- `Service`

Other chart fields can then reference an `externalRefs` entry by `id` instead of repeating the raw resource name.

## What changed

### New capabilities

| Feature | Description |
|---------|-------------|
| `externalRefs` | New top-level registry for reusable external dependencies |
| `kind: Service` | Allows `externalRefs` entries to represent external services |
| `mode: create / reference` | Controls whether the chart creates a Service or references an existing one |
| `externalServiceRef` | New env field that resolves to a referenced Service name |
| `fullnameOverride` | Override the generated service name for created Services |
| `annotations` | Per-entry annotations for created Services |

### Integration points

`externalRefs` entries can now be used in:
- `envFrom` (ConfigMap/Secret)
- `env[].valueFrom.secretKeyRef` / `configMapKeyRef`
- `env[].externalServiceRef` (Service)
- `volumes` (ConfigMap/Secret/PVC)
- `ingresses[].rules[].secretName` (Secret)
- `servicemonitor.basicAuth.existingSecret` (Secret)
- `imagePullSecrets` (Secret)

### Feature toggle

`includes.externalRefs` controls whether chart-managed `Service` resources declared through `externalRefs` are rendered.

### Schema & validation

- Array-based schema with `required: ["id", "kind"]`
- Conditional validation: `mode: create` requires `externalName` + `kind: Service`; `mode: reference` requires `name`
- `minLength: 1` on `id`, `name`, and `externalName` fields
- Unique `id` enforcement at template level
- Kind validation at every consumer site (e.g., envFrom rejects PVC/Service)

### Backwards compatibility

- Consumer fields remain type-specific and validated at render time
- Service support is added without introducing a separate second registry for external services

### Kustomize compatibility

The array format preserves simple Kustomize `nameReference` configuration:

```yaml
nameReference:
  - kind: ConfigMap
    fieldSpecs:
      - path: spec/values/externalRefs/name
        kind: HelmRelease
        group: helm.toolkit.fluxcd.io
  - kind: Secret
    fieldSpecs:
      - path: spec/values/externalRefs/name
        kind: HelmRelease
        group: helm.toolkit.fluxcd.io
  - kind: PersistentVolumeClaim
    fieldSpecs:
      - path: spec/values/externalRefs/name
        kind: HelmRelease
        group: helm.toolkit.fluxcd.io
```

## Example

```yaml
externalRefs:
  - id: app-config
    kind: ConfigMap
    name: my-app-config

  - id: ext-database
    kind: Service
    mode: create
    externalName: db.external.example.com

  - id: partner-api
    kind: Service
    mode: reference
    name: partner-api-gateway

components:
  backend:
    controller:
      envFrom:
        - externalRef: app-config
      env:
        - name: DATABASE_HOST
          externalServiceRef: ext-database
        - name: PARTNER_API_HOST
          externalServiceRef: partner-api

includes:
  externalRefs: true
```

In this example:

- `app-config` declares a reusable external `ConfigMap`
- `ext-database` declares a `Service` that the chart should create with `spec.type: ExternalName`
- `partner-api` declares an already existing service that should only be referenced
- `app-config`, `ext-database`, and `partner-api` are then reused by ID from component configuration
- `DATABASE_HOST` and `PARTNER_API_HOST` resolve service names through `externalServiceRef`

## Files changed

- `charts/common/templates/helpers/_externalrefs.tpl` (new)
- `charts/common/templates/_externalname-service.yaml` (new)
- `charts/common/templates/_container.yaml`
- `charts/common/templates/_pod.yaml`
- `charts/common/templates/includes.yaml`
- `charts/common/values.yaml`
- `charts/common/values.schema.json`
- `charts/common/ci/values.test.yaml`
- `charts/common/README.md.gotmpl`
- `charts/common/README.md`
- `charts/common/Chart.yaml`

## Testing

- `helm lint` passes
- `helm template` verified: rendered `Service` resources use `spec.type: ExternalName`, env resolution works, and existing integration points (`secretKeyRef`, `configMapKeyRef`, `envFrom`, `volumes`, ingress TLS, ServiceMonitor, `imagePullSecrets`) continue to function
