### PR TITLE
[vcluster]: better scaling reference when using sidecar

### DIFF
--- a/charts/vcluster/Chart.yaml
+++ b/charts/vcluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcluster
 description: Virtual Kubernetes Cluster
 type: application
-version: 0.16.5
+version: 0.16.6
 appVersion: 0.1.0
 keywords:
   - vcluster

--- a/charts/vcluster/README.md
+++ b/charts/vcluster/README.md
@@ -2,7 +2,7 @@
 
 __This Chart is under active development! We try to improve documentation and values consistency over time__
 
-![Version: 0.16.5](https://img.shields.io/badge/Version-0.16.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.16.6](https://img.shields.io/badge/Version-0.16.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Virtual Kubernetes Cluster
 

--- a/charts/vcluster/templates/components/kubernetes/_templates.tpl
+++ b/charts/vcluster/templates/components/kubernetes/_templates.tpl
@@ -148,7 +148,13 @@ Template for konnectivityServer containers
 - command:
   - /proxy-server
   - --logtostderr=true
+  {{- if and $kubernetes.konnectivity.enabled $kubernetes.konnectivity.server.enabled }}
+    {{- if or (eq $kubernetes.konnectivity.server.mode "HTTPConnect") (not $kubernetes.konnectivity.server.sidecar) }}
   - --server-count={{ $kubernetes.konnectivity.server.replicaCount }}
+    {{- else }}
+  - --server-count={{ $kubernetes.apiServer.replicaCount }}
+    {{- end }}
+  {{- end }}
   - --server-id=$(POD_NAME)
   - --cluster-cert=/pki/apiserver/tls.crt
   - --cluster-key=/pki/apiserver/tls.key


### PR DESCRIPTION
**What this PR does**:

Change templating of `--server-count` value in vcluster-chart template.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

When deploying the konnectivity-agent as a sidecar, the following replicable issue comes up:

- `--server-count` uses the default value of 2
  - in sidecar mode, this is roughly equivalent to "how many apiserver instances can there be"
- deployment with default values for apiserver replicas works
  - default is 2
- if you scale up the amount of apiserver-pods, you start noticing various issues
  - `k top <resource>` starts failing
  - apiserver-logs are filled with errors along the lines of `konnectivity-server E0420 14:00:51.153274       1 server.go:528] "Failed to get a backend" err="No agent available"`

**Checklist**:

- [X] Pull Request title in format `[chart]: Changed Something`
- [X] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off
