### PR TITLE
[common]: Add image digest support

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 12.7.0
+version: 12.8.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -27,5 +27,4 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
-    - "[Changed]: extra annotations and labels support sprig statements"
-    - "[Added]: Possibility to optionally set appVersion in values"
+    - "[Added]: Support image digest in container image reference"

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 12.7.0](https://img.shields.io/badge/Version-12.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 12.8.0](https://img.shields.io/badge/Version-12.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/templates/_container.yaml
+++ b/charts/common/templates/_container.yaml
@@ -6,7 +6,7 @@
 {{- $containerValues := .containerValues }}
 {{- $configFiles := .configFiles }}
 - name: {{ $containerName }}
-  image: "{{ $containerValues.image.repository }}:{{ $containerValues.image.tag | default $root.Values.defaultTag }}"
+  image: "{{ $containerValues.image.repository }}{{ if $containerValues.image.digest }}@{{ $containerValues.image.digest }}{{ else }}:{{ $containerValues.image.tag | default $root.Values.defaultTag }}{{ end }}"
   imagePullPolicy: {{ default "IfNotPresent" $containerValues.image.pullPolicy | quote }}
   {{- with $containerValues.command }}
   command: {{ toYaml . | nindent 4 }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -540,6 +540,8 @@ components:
             # tag: "1.16"
             #  pullPolicy can be set to "Always". Comment out for using default ("IfNotPresent")
             # pullPolicy: Always
+            #  digest pins the image to a specific digest (e.g. sha256:...). When set, tag is ignored.
+            # digest: ""
 
           # command Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided.
           # command: []


### PR DESCRIPTION
<!--
Thank you for contributing to bedag/helm-charts.
-->

**What this PR does**:
Adds support for pinning container images by digest (`sha256:...`) in the common chart. When `image.digest` is set, the rendered image reference uses `repository@digest` instead of `repository:tag`. Tag is ignored when digest is specified.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Notes for Reviewer**:
The change is fully backwards-compatible — existing values without `digest` render identically to before.

**Checklist**:

- [x] Pull Request title in format `[common]: Add image digest support`
- [x] Updated documentation in the `README.md.gotmpl` file and executed `helm-docs`
- [x] Chart Version bumped ✓ (12.7.0 → 12.8.0)
- [x] All commits are signed-off
