### PR TITLE
[common]: allow configuring StatefulSet governing Service name

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 12.8.0
+version: 12.9.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -27,4 +27,8 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
-    - "[Added]: Support image digest in container image reference"
+    - kind: added
+      description: StatefulSet serviceName now matches the governing Service name via optional controller.serviceName
+      links:
+        - name: GitHub Issue
+          url: https://github.com/bedag/helm-charts/issues/185

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 12.8.0](https://img.shields.io/badge/Version-12.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 12.9.0](https://img.shields.io/badge/Version-12.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/ci/values.test.yaml
+++ b/charts/common/ci/values.test.yaml
@@ -175,6 +175,7 @@ components:
     services:
       service-2:
         deploy: true
+        clusterIP: "None"
     # end common.service
     # start common.networkpolicy
     networkpolicies:
@@ -188,6 +189,9 @@ components:
     controller:
       deploy: true
       type: "StatefulSet"
+      # serviceName has to reference an actual "services" entry (see above) so that
+      # spec.serviceName matches the governing Service's metadata.name.
+      serviceName: service-2
 
       extraVolumeClaimTemplates:
         - metadata:

--- a/charts/common/templates/_statefulset.yaml
+++ b/charts/common/templates/_statefulset.yaml
@@ -16,7 +16,11 @@ metadata:
 spec:
   replicas: {{ $statefulset.replicas | default 1 }}
   revisionHistoryLimit: {{ $statefulset.revisionHistoryLimit | default 3 }}
+  {{- if $statefulset.serviceName }}
+  serviceName: {{ template "library.name" $root }}-{{ $name }}-{{ $statefulset.serviceName }}
+  {{- else }}
   serviceName: {{ template "library.name" $root }}-{{ $name }}
+  {{- end }}
   updateStrategy:
     type: {{ $statefulset.updateStrategy | default "RollingUpdate" }}
   selector:

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -864,6 +864,9 @@
                   "type": "boolean",
                   "default": false
                 },
+                "serviceName": {
+                  "type": "string"
+                },
                 "type": {
                   "type": "string",
                   "enum": [

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -311,6 +311,13 @@ components:
       # type has to be "Deployment", "StatefulSet", "Job" or "CronJob"
       type: "Deployment"
 
+      # serviceName is only used when type is "StatefulSet". It sets the governing Service
+      # (spec.serviceName) used for the StatefulSet's stable network identity. It has to be
+      # the key of a service defined under this component's "services" (see start common.service),
+      # so that the resulting Service name matches. Comment out to fall back to the component
+      # name, which only matches an actual Service if no "services" suffix is used.
+      # serviceName: service-1
+
       # Extra annotations on all Pods
       # We use this for example to set the prometheus annotations.
       extraAnnotations: {}


### PR DESCRIPTION
 
**What this PR does**:
Fixes the `common` chart's StatefulSet governing Service name mismatch: `common.statefulset`'s `spec.serviceName` (`<library.name>-<component>`) never matched the Service name produced by `common.service` (`<library.name>-<component>-<servicename>`), so the governing/headless service link was broken for every StatefulSet defined via this chart.
 
Adds an optional `controller.serviceName` field. When set, `spec.serviceName` is rendered as `<library.name>-<component>-<controller.serviceName>`, matching a `services.<name>` entry under the same component. When unset, the previous naming is kept for backwards compatibility.
 
**Which issue this PR fixes** 
fixes #185 
 
**Notes for Reviewer**:
- `charts/common/templates/_statefulset.yaml`: conditionally render `serviceName` using `controller.serviceName` when present.
- `charts/common/values.schema.json`: added optional `serviceName` string under `controller`.
- `charts/common/values.yaml`: documented the new field.
- Chart version bumped `12.8.0` → `12.9.0` (additive/backwards-compatible change).
 
**Checklist**:
 
- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs`
- [x] Chart Version bumped
- [x] All commits are signed-off
