### PR TITLE
[common]: Add multi-port support for component services

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 12.9.0
+version: 12.10.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -28,7 +28,12 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: added
-      description: StatefulSet serviceName now matches the governing Service name via optional controller.serviceName
+      description: Added components.<name>.services.<name>.ports list to allow defining multiple ports on a single Service (e.g. for a StatefulSet's governing/headless service)
       links:
         - name: GitHub Issue
-          url: https://github.com/bedag/helm-charts/issues/185
+          url: https://github.com/bedag/helm-charts/issues/187
+    - kind: added
+      description: Added components.<name>.services.<name>.publishNotReadyAddresses to support StatefulSet governing services addressable before pods are ready
+      links:
+        - name: GitHub Issue
+          url: https://github.com/bedag/helm-charts/issues/187

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 12.9.0](https://img.shields.io/badge/Version-12.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 12.10.0](https://img.shields.io/badge/Version-12.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/ci/values.test.yaml
+++ b/charts/common/ci/values.test.yaml
@@ -176,6 +176,14 @@ components:
       service-2:
         deploy: true
         clusterIP: "None"
+        publishNotReadyAddresses: true
+        ports:
+          - name: data
+            port: 9200
+            targetPort: 9200
+          - name: config
+            port: 9300
+            targetPort: 9300
     # end common.service
     # start common.networkpolicy
     networkpolicies:

--- a/charts/common/templates/_service.yaml
+++ b/charts/common/templates/_service.yaml
@@ -31,11 +31,24 @@ spec:
   {{- if $service.clusterIP }}
   clusterIP: {{ $service.clusterIP }}
   {{- end }}
+  {{- if hasKey $service "publishNotReadyAddresses" }}
+  publishNotReadyAddresses: {{ $service.publishNotReadyAddresses }}
+  {{- end }}
+  {{- if $service.ports }}
+  ports:
+  {{- range $service.ports }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol | default "TCP" }}
+  {{- end }}
+  {{- else }}
   ports:
     - name: {{ $service.name | default "http" }}
       port: {{ $service.port | default "80" }}
       targetPort: {{ $service.targetPort | default "http" }}
       protocol: {{ $service.protocol | default "TCP" }}
+  {{- end }}
   selector:
 {{- if not $service.overrideSelectors }}
     app.kubernetes.io/name: {{ template "library.name" $root }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -241,12 +241,30 @@ components:
         # protocol:
         #  clusterIP is optional with an empty default
         # clusterIP: "None"
+        #  publishNotReadyAddresses is optional and unset by default. Useful for StatefulSet
+        #  governing/headless services so pods are addressable via DNS before they're ready.
+        # publishNotReadyAddresses: true
         #  overrideSelectors is optional for overridding the default labels: 'app.kubernetes.io/name' & 'app.kubernetes.io/component'
         # overrideSelectors:
         #   label2.1: "label2"
         #   label2.2: "label2"
         #  sessionAffinity supports "ClientIP" and "None". Used to maintain session affinity. Default value is "None".
         # sessionAffinity: "ClientIP"
+        #  ports is optional and allows defining multiple ports on a single Service (e.g. for a
+        #  StatefulSet's governing service). If set, it takes precedence over the singular
+        #  name/port/targetPort/protocol fields above. Each entry supports:
+        #    name        - required, port name
+        #    port        - required, service port
+        #    targetPort  - required, target port on the pod
+        #    protocol    - optional, default "TCP"
+        # ports:
+        #   - name: data
+        #     port: 9200
+        #     targetPort: 9200
+        #   - name: config
+        #     port: 9300
+        #     targetPort: 9300
+        #     protocol: TCP
     # end common.service
     # start common.networkpolicy
     # networkpolicy allows access from outside of the namespace or from other pods


### PR DESCRIPTION
**What this PR does**:
Extends the common chart's Service template `templates/_service.yaml` to support multiple ports on a single Kubernetes `Service`, needed for StatefulSet governing/headless services. Adds an optional `ports` list per `components.<name>.services.<name>` entry (`name`, `port`, `targetPort`, `protocol`), which takes precedence over the existing singular `name`/`port`/`targetPort`/`protocol` fields when present. Also adds an optional `publishNotReadyAddresses` field for StatefulSet governing services.

Fully backwards compatible, existing single-port service configs render identically.

**Which issue this PR fixes**
fixes https://github.com/bedag/helm-charts/issues/187

**Notes for Reviewer**:
- No `values.schema.json` changes required since the `services` schema has no `additionalProperties: false` restriction, so the new fields are already permitted.

**Checklist**:

- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs` 
- [x] Chart Version bumped
- [x] All commits are signed-off